### PR TITLE
Add operation_id for routes

### DIFF
--- a/app/routers/gamemodes.py
+++ b/app/routers/gamemodes.py
@@ -19,6 +19,7 @@ router = APIRouter()
         "Get a list of Overwatch gamemodes : Assault, Escort, Hybrid, etc."
         "<br />**Cache TTL : 1 day.**"
     ),
+    operation_id="list_map_gamemodes",
 )
 @validation_error_handler(response_model=GamemodeDetails)
 async def list_map_gamemodes(

--- a/app/routers/heroes.py
+++ b/app/routers/heroes.py
@@ -22,6 +22,7 @@ router = APIRouter()
         "Get a list of Overwatch heroes, which can be filtered using roles. "
         "<br />**Cache TTL : 1 day.**"
     ),
+    operation_id="list_heroes",
 )
 @validation_error_handler(response_model=HeroShort)
 async def list_heroes(
@@ -49,6 +50,7 @@ async def list_heroes(
         "Get data about an Overwatch hero : description, abilities, story, etc. "
         "<br />**Cache TTL : 1 day.**"
     ),
+    operation_id="get_hero",
 )
 @validation_error_handler(response_model=Hero)
 async def get_hero(

--- a/app/routers/maps.py
+++ b/app/routers/maps.py
@@ -17,6 +17,7 @@ router = APIRouter()
         "Get a list of Overwatch maps : Hanamura, King's Row, Dorado, etc."
         "<br />**Cache TTL : 1 day.**"
     ),
+    operation_id="list_maps",
 )
 @validation_error_handler(response_model=Map)
 async def list_maps(

--- a/app/routers/players.py
+++ b/app/routers/players.py
@@ -100,6 +100,7 @@ router = APIRouter()
         "find the associated player_id to use in order to request career data."
         "<br />**Cache TTL : 1 hour.**"
     ),
+    operation_id="search_players",
 )
 @validation_error_handler(response_model=PlayerSearchResult)
 async def search_players(
@@ -137,6 +138,7 @@ async def search_players(
         "Get player summary : name, avatar, competitive ranks, etc. "
         "<br />**Cache TTL : 1 hour.**"
     ),
+    operation_id="get_player_summary",
 )
 @validation_error_handler(response_model=PlayerSummary)
 async def get_player_summary(
@@ -165,6 +167,7 @@ async def get_player_summary(
         "<br />Default behaviour : all gamemodes and platforms are taken in account."
         "<br />**Cache TTL : 1 hour.**"
     ),
+    operation_id="get_player_stats_summary",
 )
 @validation_error_handler(response_model=PlayerStatsSummary)
 async def get_player_stats_summary(
@@ -209,6 +212,7 @@ async def get_player_stats_summary(
         "data about a specific hero of your choice."
         "<br />**Cache TTL : 1 hour.**"
     ),
+    operation_id="get_player_career_stats",
 )
 @validation_error_handler(response_model=PlayerCareerStats)
 async def get_player_career_stats(
@@ -231,6 +235,7 @@ async def get_player_career_stats(
         "exposes labels of the categories and statistics."
         "<br />**Cache TTL : 1 hour.**"
     ),
+    operation_id="get_player_stats",
 )
 @validation_error_handler(response_model=CareerStats)
 async def get_player_stats(
@@ -250,6 +255,7 @@ async def get_player_stats(
     description=(
         "Get all player data : summary and statistics with labels.<br />**Cache TTL : 1 hour.**"
     ),
+    operation_id="get_player_career",
 )
 @validation_error_handler(response_model=Player)
 async def get_player_career(

--- a/app/routers/roles.py
+++ b/app/routers/roles.py
@@ -17,6 +17,7 @@ router = APIRouter()
     tags=[RouteTag.HEROES],
     summary="Get a list of roles",
     description="Get a list of available Overwatch roles.<br />**Cache TTL : 1 day.**",
+    operation_id="list_roles",
 )
 @validation_error_handler(response_model=RoleDetail)
 async def list_roles(


### PR DESCRIPTION
FastAPI allows us to set a unique identifier for each route called `operation_id`. This `operation_id` is mainly used by third party libraries to identified each endpoint easily and to generate code from it.

Currently, running the following command to generate a Typescript client from your API specifications will result in some junky method names

```node
// "openapi-typescript-codegen": "^0.20.1"

openapi --input https://overfast-api.tekrop.fr/openapi.json --output ./client --client axios
```

![image](https://github.com/TeKrop/overfast-api/assets/46346622/8b5bc812-6adc-4864-a2c9-ff1ac7f7eab8)


Setting the operation_id will allow the generated client to have more simpler name for each method 

![image](https://github.com/TeKrop/overfast-api/assets/46346622/befdca94-6bfa-4549-aabb-4657c8a7cae8)


(I can share my whole config if you want to generate a Typescript client by yourself 😄)
