### PR TITLE
fix: fixed support for champion rank (ultimate)

### DIFF
--- a/app/common/enums.py
+++ b/app/common/enums.py
@@ -117,7 +117,7 @@ class CompetitiveDivision(StrEnum):
     DIAMOND = "diamond"
     MASTER = "master"
     GRANDMASTER = "grandmaster"
-    CHAMPION = "champion"
+    ULTIMATE = "ultimate"
 
 
 class Locale(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "overfast-api"
-version = "2.25.0"
+version = "2.25.1"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = "MIT"
 authors = ["Valentin PORCHET <valentin.porchet@proton.me>"]

--- a/tests/parsers/test_helpers.py
+++ b/tests/parsers/test_helpers.py
@@ -74,8 +74,8 @@ def test_get_computed_stat_value(input_str: str, result: float | str):
             CompetitiveDivision.GRANDMASTER,
         ),
         (
-            "https://static.playoverwatch.com/img/pages/career/icons/rank/ChampionTier-3-e55e61f68f.png",
-            CompetitiveDivision.CHAMPION,
+            "https://static.playoverwatch.com/img/pages/career/icons/rank/Rank_UltimateTier-99f8248b65.png",
+            CompetitiveDivision.ULTIMATE,
         ),
     ],
 )


### PR DESCRIPTION
For some reason, new "Champion" rank on OW2 is named "Ultimate" on their page 🤡 