### PR TITLE
feat: adding Blizzard ID to the search JSON

### DIFF
--- a/app/handlers/search_players_request_handler.py
+++ b/app/handlers/search_players_request_handler.py
@@ -94,6 +94,7 @@ class SearchPlayersRequestHandler(ApiRequestMixin):
                     "namecard": self.get_namecard_url(player, player_id),
                     "title": self.get_title(player, player_id),
                     "career_url": f"{settings.app_base_url}/players/{player_id}",
+                    "blizzard_id": player["url"],
                 },
             )
         return transformed_players

--- a/app/models/players.py
+++ b/app/models/players.py
@@ -62,6 +62,12 @@ class PlayerShort(BaseModel):
         description="Player's career OverFast API URL (Get player career data)",
         examples=["https://overfast-api.tekrop.fr/players/TeKrop-2217"],
     )
+    blizzard_id: str = Field(
+        ...,
+        title="Blizzard ID",
+        description="Blizzard unique identifier of the player (hexadecimal)",
+        examples=["c65b8798bc61d6ffbba120%7Ccfe9dd77a4382165e2b920bdcc035949"],
+    )
 
 
 class PlayerSearchResult(BaseModel):

--- a/tests/fixtures/json/search_players/search_players_api_result.json
+++ b/tests/fixtures/json/search_players/search_players_api_result.json
@@ -7,7 +7,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/04097daa03cfaf51c8fb28dcb4bc2323d4dfaec74298ab929eee7c991916c2be.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/DEKK-11775"
+            "career_url": "https://overfast-api.tekrop.fr/players/DEKK-11775",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "DEKK-21259",
@@ -15,7 +16,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/8fb752e425af261dff0c2fb39535e06f9b110dfafcde7c8df321bc836811ba59.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/DEKK-21259"
+            "career_url": "https://overfast-api.tekrop.fr/players/DEKK-21259",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-11904",
@@ -23,7 +25,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/3e0ffbec206ae87769fa8dcd8779bb209716ed787a2b8a710789372403134e7b.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-11904"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-11904",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-11906",
@@ -31,7 +34,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/b965f562f97f1fd1b258312810640183a1712215b2f6117c262881f263380dc3.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-11906"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-11906",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-1380",
@@ -39,7 +43,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/c3090e3a1dccc58f143ff53801bc0cecb139f0eb1278f157d0b5e29db9104bed.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-1380"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-1380",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-1637",
@@ -47,7 +52,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/c3090e3a1dccc58f143ff53801bc0cecb139f0eb1278f157d0b5e29db9104bed.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-1637"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-1637",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-1766",
@@ -55,7 +61,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/c3090e3a1dccc58f143ff53801bc0cecb139f0eb1278f157d0b5e29db9104bed.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-1766"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-1766",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-21129",
@@ -63,7 +70,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/83acb9ede346a80e915eadf9ac766f8f80365bafbbfa419dfa07fc98861ff353.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21129"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21129",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-21260",
@@ -71,7 +79,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/c3090e3a1dccc58f143ff53801bc0cecb139f0eb1278f157d0b5e29db9104bed.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21260"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21260",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-21386",
@@ -79,7 +88,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/952500f69a9174e96dabf9a578ee9645cd3e0481c8007099e63ddd387b27e9f9.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21386"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21386",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-2162",
@@ -87,7 +97,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/5b862f112bd8065f03c95472fa8f8636791005f3a34c497472d8e1d2944de289.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-2162"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-2162",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-21771",
@@ -95,7 +106,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/8d85c969c1f55c60a6e49de1f81edc711646480fb652002efafdfe7f3d5fd13d.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21771"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21771",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-21904",
@@ -103,7 +115,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/21b9e01301442344ccf132814d3e07d3e5e84d55f7f36e5bdf53dea4a004e7f0.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21904"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-21904",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         },
         {
             "player_id": "Dekk-2677",
@@ -111,7 +124,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/10c21dd702b2b6ffa7972c58124b22910742fbdb3421c5551ad33184dc57b67a.png",
             "namecard": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/757219956129146d84617a7e713dfca1bc33ea27cf6c73df60a33d02a147edc1.png",
             "title": "Bytefixer",
-            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-2677"
+            "career_url": "https://overfast-api.tekrop.fr/players/Dekk-2677",
+            "blizzard_id": "d65ba781fe23cdfabe%7C9b3063608098cdbf1b9825d8664f4d96"
         },
         {
             "player_id": "dekk-2548",
@@ -119,7 +133,8 @@
             "avatar": "https://d15f34w2p8l1cc.cloudfront.net/overwatch/c2b96b7d4d633f1ec455bc4cfb5c7ae10ea16d106b2ce264238c6760f457a671.png",
             "namecard": null,
             "title": null,
-            "career_url": "https://overfast-api.tekrop.fr/players/dekk-2548"
+            "career_url": "https://overfast-api.tekrop.fr/players/dekk-2548",
+            "blizzard_id": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
         }
     ]
 }

--- a/tests/fixtures/json/search_players/search_players_blizzard_result.json
+++ b/tests/fixtures/json/search_players/search_players_blizzard_result.json
@@ -6,7 +6,8 @@
         "lastUpdated": 1678488893,
         "namecard": "0x0250000000005510",
         "portrait": "0x0250000000001598",
-        "title": "0x025000000000555E"
+        "title": "0x025000000000555E",
+        "url": "d65ba781fe23cdfabe%7C9b3063608098cdbf1b9825d8664f4d96"
     },
     {
         "battleTag": "Dekk#21386",
@@ -15,7 +16,8 @@
         "lastUpdated": 1677947164,
         "namecard": "0x0000000000000000",
         "portrait": "0x0250000000000315",
-        "title": "0x0000000000000000"
+        "title": "0x0000000000000000",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "dekk#2548",
@@ -24,7 +26,8 @@
         "lastUpdated": 1676811985,
         "namecard": "0x0000000000000000",
         "portrait": "0x0250000000001374",
-        "title": "0x0000000000000000"
+        "title": "0x0000000000000000",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#21904",
@@ -33,7 +36,8 @@
         "lastUpdated": 1676730323,
         "namecard": "0x0000000000000000",
         "portrait": "0x0250000000004D59",
-        "title": "0x0000000000000000"
+        "title": "0x0000000000000000",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "DEKK#21259",
@@ -42,76 +46,87 @@
         "lastUpdated": 1676555200,
         "namecard": "0x0000000000000000",
         "portrait": "0x02500000000002F9",
-        "title": "0x0000000000000000"
+        "title": "0x0000000000000000",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#2162",
         "frame": "0x02500000000009CD",
         "isPublic": false,
         "lastUpdated": 1671155709,
-        "portrait": "0x0250000000000BBA"
+        "portrait": "0x0250000000000BBA",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#1637",
         "frame": "0x0250000000000918",
         "isPublic": false,
         "lastUpdated": 1670258731,
-        "portrait": "0x02500000000002F7"
+        "portrait": "0x02500000000002F7",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#21260",
         "frame": "0x0250000000000918",
         "isPublic": false,
         "lastUpdated": 1668452370,
-        "portrait": "0x02500000000002F7"
+        "portrait": "0x02500000000002F7",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#21129",
         "frame": "0x0250000000000918",
         "isPublic": false,
         "lastUpdated": 1668372404,
-        "portrait": "0x0250000000005643"
+        "portrait": "0x0250000000005643",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#11906",
         "frame": "0x0250000000000919",
         "isPublic": false,
         "lastUpdated": 1667959199,
-        "portrait": "0x0250000000000D60"
+        "portrait": "0x0250000000000D60",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#11904",
         "frame": "0x0250000000000918",
         "isPublic": false,
         "lastUpdated": 1666924000,
-        "portrait": "0x0250000000000B14"
+        "portrait": "0x0250000000000B14",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#21771",
         "frame": "0x0250000000000921",
         "isPublic": false,
         "lastUpdated": 1666737903,
-        "portrait": "0x02500000000012DB"
+        "portrait": "0x02500000000012DB",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#1380",
         "frame": "0x0250000000000918",
         "isPublic": false,
         "lastUpdated": 1666538443,
-        "portrait": "0x02500000000002F7"
+        "portrait": "0x02500000000002F7",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "DEKK#11775",
         "frame": "0x0250000000000920",
         "isPublic": false,
         "lastUpdated": 1665953911,
-        "portrait": "0x025000000000115C"
+        "portrait": "0x025000000000115C",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     },
     {
         "battleTag": "Dekk#1766",
         "frame": "0x0250000000000918",
         "isPublic": false,
         "lastUpdated": 1665287787,
-        "portrait": "0x02500000000002F7"
+        "portrait": "0x02500000000002F7",
+        "url": "d67b87a1fe23caffbca9%7Ce071d6c2df64c91dc7ad8f0eb73d5d05"
     }
 ]

--- a/tests/fixtures/json/search_players/search_tekrop_blizzard_result.json
+++ b/tests/fixtures/json/search_players/search_tekrop_blizzard_result.json
@@ -6,6 +6,7 @@
         "lastUpdated": 1678536999,
         "namecard": "0x02500000000056EA",
         "portrait": "0x02500000000056C8",
-        "title": "0x025000000000555E"
+        "title": "0x025000000000555E",
+        "url": "c65b8798bc61d6ffbba120%7Ccfe9dd77a4382165e2b920bdcc035949"
     }
 ]


### PR DESCRIPTION
As stated in #96, there's a new property on search. This will add it to the JSON from the search results.

This is a selfish addition as a way of preparing for the potential risk of them removing the automatic redirects from from the old URL format to the new format. This new property will allow us to capture the ID and start using that instead.