### PR TITLE
fix: fixed two issues with Blizzard profiles

### DIFF
--- a/app/parsers/helpers.py
+++ b/app/parsers/helpers.py
@@ -35,8 +35,11 @@ def get_computed_stat_value(input_str: str) -> str | float | int:
     if re.match(r"^-?\d+\.\d+$", input_str):
         return float(input_str)
 
-    # Zero time fought with a character if "--", else default value
-    return 0 if input_str == "--" else input_str
+    # Return 0 value if :
+    # - Zero time fought with a character ("--")
+    # - Invalid value in DOM ("NaN")
+    # Else default value
+    return 0 if input_str in {"--", "NaN"} else input_str
 
 
 def get_division_from_icon(rank_url: str) -> CompetitiveDivision:

--- a/app/parsers/player_parser.py
+++ b/app/parsers/player_parser.py
@@ -365,7 +365,12 @@ class PlayerParser(APIParser):
         }
 
         for category in CareerHeroesComparisonsCategory:
-            if category.value not in heroes_comparisons:
+            # Sometimes, Blizzard exposes the categories without any value
+            # In that case, we must assume we have no data at all
+            if (
+                category.value not in heroes_comparisons
+                or not heroes_comparisons[category.value]["values"]
+            ):
                 heroes_comparisons[category.value] = None
 
         return heroes_comparisons

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "overfast-api"
-version = "2.32.0"
+version = "2.32.1"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = "MIT"
 authors = ["Valentin PORCHET <valentin.porchet@proton.me>"]

--- a/tests/parsers/test_helpers.py
+++ b/tests/parsers/test_helpers.py
@@ -34,6 +34,8 @@ from app.parsers import helpers
         ("-86.96", -86.96),
         # Zero time fought with a character
         ("--", 0),
+        # Invalid value (not a number)
+        ("NaN", 0),
         # Default value for anything else
         ("string", "string"),
     ],


### PR DESCRIPTION
Fixed two issues encountered on Blizzard pages : 
- Sometimes there is a "NaN" value instead of float or int. Returning 0 for these
![image](https://github.com/user-attachments/assets/76ff612d-8f15-4630-9592-95cd74d3ef21)
- Sometimes there is no heroes comparisons data but the dropdown is still here even if it shouldn't
![image](https://github.com/user-attachments/assets/e29fdde0-835d-4f39-9245-ce3ea6224518)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses two bugs in Blizzard profiles: handling 'NaN' values by returning 0 and ensuring the heroes comparisons dropdown does not appear when there is no data. Additionally, test cases were added to verify the 'NaN' value handling.

- **Bug Fixes**:
    - Fixed issue where 'NaN' values were returned instead of 0 in Blizzard profiles.
    - Fixed issue where the heroes comparisons dropdown appeared without data in Blizzard profiles.
- **Tests**:
    - Added test cases to ensure 'NaN' values are correctly converted to 0.

<!-- Generated by sourcery-ai[bot]: end summary -->