### PR TITLE
feat: updated uv to v0.4.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,15 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
-        uv-version: ["0.4.0"]
+        uv-version: ["0.4.5"]
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up uv
-      run: curl -LsSf https://astral.sh/uv/${{ matrix.uv-version }}/install.sh | sh
+      uses: astral-sh/setup-uv@v1
+      with:
+        version: "${{ matrix.uv-version }}"
 
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
 # Build arguments
 ARG PYTHON_VERSION=3.12
-ARG UV_VERSION=0.4.0
-
-# Create a temporary stage to pull the uv binary
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-stage
+ARG UV_VERSION=0.4.5
 
 # Main stage
-FROM python:${PYTHON_VERSION}-alpine AS main
-
-# Copy the uv binary from the temporary stage to the main stage
-COPY --from=uv-stage /uv /bin/uv
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}-python${PYTHON_VERSION}-alpine AS main
 
 # Copy only requirements (caching in Docker layer)
 COPY pyproject.toml uv.lock /code/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,14 @@
 ARG PYTHON_VERSION=3.12
 ARG UV_VERSION=0.4.5
 
+# Create a temporary stage to pull the uv binary
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-stage
+
 # Main stage
-FROM ghcr.io/astral-sh/uv:${UV_VERSION}-python${PYTHON_VERSION}-alpine AS main
+FROM python:${PYTHON_VERSION}-alpine AS main
+
+# Copy the uv binary from the temporary stage to the main stage
+COPY --from=uv-stage /uv /bin/uv
 
 # Copy only requirements (caching in Docker layer)
 COPY pyproject.toml uv.lock /code/


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI workflow to use a new method for setting up uv by switching from a curl command to the 'astral-sh/setup-uv@v1' GitHub Action, and update the uv version to 0.4.5.

CI:
- Update the CI workflow to use the 'astral-sh/setup-uv@v1' action for setting up uv, replacing the previous curl command.

<!-- Generated by sourcery-ai[bot]: end summary -->