### PR TITLE
feat: updated gh actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v3
       with:
         version: "${{ matrix.uv-version }}"
 
@@ -41,7 +41,7 @@ jobs:
 
     - name: Update test coverage badge
       if: github.event_name == 'push'
-      uses: schneegans/dynamic-badges-action@v1.6.0
+      uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_SECRET }}
         gistID: 1362ebafcd51d3f65dae7935b1d322eb
@@ -54,7 +54,7 @@ jobs:
 
     - name: Update python version badge
       if: github.event_name == 'push'
-      uses: schneegans/dynamic-badges-action@v1.6.0
+      uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_SECRET }}
         gistID: 15a234815aa74059953a766a10e92688


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update GitHub Actions versions for 'setup-uv' to v3 and 'dynamic-badges-action' to v1.7.0 in the CI workflow.