### PR TITLE
updated ruff, and updated code accordingly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        uv-version: ["0.5.1"]
+        uv-version: ["0.5.4"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,10 @@ default_language_version:
     python: python3.12
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.8.0
     hooks:
       - id: ruff
         name: (ruff) Linting and fixing code
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
         name: (ruff) Formatting code
-  - repo: https://github.com/sourcery-ai/sourcery
-    rev: v1.23.0
-    hooks:
-      - id: sourcery
-        name: (sourcery) Checking code quality
-        args: [--diff=git diff HEAD, --no-summary]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build arguments
 ARG PYTHON_VERSION=3.13
-ARG UV_VERSION=0.5.1
+ARG UV_VERSION=0.5.4
 
 # Create a temporary stage to pull the uv binary
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-stage

--- a/app/heroes/router.py
+++ b/app/heroes/router.py
@@ -1,5 +1,7 @@
 """Heroes endpoints router : heroes list, heroes details, etc."""
 
+from typing import Annotated
+
 from fastapi import APIRouter, Path, Query, Request, status
 
 from app.enums import Locale, RouteTag
@@ -27,8 +29,10 @@ router = APIRouter()
 )
 async def list_heroes(
     request: Request,
-    role: Role = Query(None, title="Role filter"),
-    locale: Locale = Query(Locale.ENGLISH_US, title="Locale to be displayed"),
+    role: Annotated[Role | None, Query(title="Role filter")] = None,
+    locale: Annotated[
+        Locale, Query(title="Locale to be displayed")
+    ] = Locale.ENGLISH_US,
 ) -> list[HeroShort]:
     return await ListHeroesController(request).process_request(
         role=role,
@@ -55,8 +59,10 @@ async def list_heroes(
 )
 async def get_hero(
     request: Request,
-    hero_key: HeroKey = Path(title="Key name of the hero"),
-    locale: Locale = Query(Locale.ENGLISH_US, title="Locale to be displayed"),
+    hero_key: Annotated[HeroKey, Path(title="Key name of the hero")],
+    locale: Annotated[
+        Locale, Query(title="Locale to be displayed")
+    ] = Locale.ENGLISH_US,
 ) -> Hero:
     return await GetHeroController(request).process_request(
         hero_key=hero_key,

--- a/app/maps/router.py
+++ b/app/maps/router.py
@@ -1,5 +1,7 @@
 """Maps endpoints router : maps list, etc."""
 
+from typing import Annotated
+
 from fastapi import APIRouter, Query, Request
 
 from app.enums import RouteTag
@@ -23,10 +25,12 @@ router = APIRouter()
 )
 async def list_maps(
     request: Request,
-    gamemode: MapGamemode = Query(
-        None,
-        title="Gamemode filter",
-        description="Filter maps available for a specific gamemode",
-    ),
+    gamemode: Annotated[
+        MapGamemode | None,
+        Query(
+            title="Gamemode filter",
+            description="Filter maps available for a specific gamemode",
+        ),
+    ] = None,
 ) -> list[Map]:
     return await ListMapsController(request).process_request(gamemode=gamemode)

--- a/app/players/parsers/player_career_parser.py
+++ b/app/players/parsers/player_career_parser.py
@@ -44,7 +44,6 @@ class PlayerCareerParser(BasePlayerParser):
     """Overwatch player profile page Parser class"""
 
     root_path = settings.career_path
-    timeout = settings.career_path_cache_timeout
     valid_http_codes: ClassVar[list] = [
         200,  # Classic response
         404,  # Player Not Found response, we want to handle it here

--- a/app/players/router.py
+++ b/app/players/router.py
@@ -110,17 +110,22 @@ router = APIRouter()
 )
 async def search_players(
     request: Request,
-    name: str = Query(
-        title="Player nickname to search",
-        examples=["TeKrop"],
-    ),
-    order_by: str = Query(
-        "name:asc",
-        title="Ordering field and the way it's arranged (asc[ending]/desc[ending])",
-        pattern=r"^(player_id|name|last_updated_at):(asc|desc)$",
-    ),
-    offset: int = Query(0, title="Offset of the results", ge=0),
-    limit: int = Query(20, title="Limit of results per page", gt=0),
+    name: Annotated[
+        str,
+        Query(
+            title="Player nickname to search",
+            examples=["TeKrop"],
+        ),
+    ],
+    order_by: Annotated[
+        str,
+        Query(
+            title="Ordering field and the way it's arranged (asc[ending]/desc[ending])",
+            pattern=r"^(player_id|name|last_updated_at):(asc|desc)$",
+        ),
+    ] = "name:asc",
+    offset: Annotated[int, Query(title="Offset of the results", ge=0)] = 0,
+    limit: Annotated[int, Query(title="Limit of results per page", gt=0)] = 20,
 ) -> PlayerSearchResult:
     return await SearchPlayersController(request).process_request(
         name=name,
@@ -172,24 +177,28 @@ async def get_player_summary(
 async def get_player_stats_summary(
     request: Request,
     commons: CommonsPlayerDep,
-    gamemode: PlayerGamemode = Query(
-        None,
-        title="Gamemode",
-        description=(
-            "Filter on a specific gamemode. If not specified, the data of "
-            "every gamemode will be combined."
+    gamemode: Annotated[
+        PlayerGamemode | None,
+        Query(
+            title="Gamemode",
+            description=(
+                "Filter on a specific gamemode. If not specified, the data of "
+                "every gamemode will be combined."
+            ),
+            examples=["competitive"],
         ),
-        examples=["competitive"],
-    ),
-    platform: PlayerPlatform = Query(
-        None,
-        title="Platform",
-        description=(
-            "Filter on a specific platform. If not specified, the data of "
-            "every platform will be combined."
+    ] = None,
+    platform: Annotated[
+        PlayerPlatform | None,
+        Query(
+            title="Platform",
+            description=(
+                "Filter on a specific platform. If not specified, the data of "
+                "every platform will be combined."
+            ),
+            examples=["pc"],
         ),
-        examples=["pc"],
-    ),
+    ] = None,
 ) -> PlayerStatsSummary:
     return await GetPlayerStatsSummaryController(request).process_request(
         player_id=commons.get("player_id"),
@@ -260,18 +269,22 @@ async def get_player_stats(
 async def get_player_career(
     request: Request,
     commons: CommonsPlayerDep,
-    gamemode: PlayerGamemode = Query(
-        None,
-        title="Gamemode",
-        description="Filter on a specific gamemode. All gamemodes are displayed by default.",
-        examples=["competitive"],
-    ),
-    platform: PlayerPlatform = Query(
-        None,
-        title="Platform",
-        description="Filter on a specific platform. All platforms are displayed by default.",
-        examples=["pc"],
-    ),
+    gamemode: Annotated[
+        PlayerGamemode | None,
+        Query(
+            title="Gamemode",
+            description="Filter on a specific gamemode. All gamemodes are displayed by default.",
+            examples=["competitive"],
+        ),
+    ] = None,
+    platform: Annotated[
+        PlayerPlatform | None,
+        Query(
+            title="Platform",
+            description="Filter on a specific platform. All platforms are displayed by default.",
+            examples=["pc"],
+        ),
+    ] = None,
 ) -> Player:
     return await GetPlayerCareerController(request).process_request(
         player_id=commons.get("player_id"),

--- a/app/roles/router.py
+++ b/app/roles/router.py
@@ -1,5 +1,7 @@
 """Roles endpoints router : roles list, etc."""
 
+from typing import Annotated
+
 from fastapi import APIRouter, Query, Request
 
 from app.enums import Locale, RouteTag
@@ -24,6 +26,8 @@ router = APIRouter()
 )
 async def list_roles(
     request: Request,
-    locale: Locale = Query(Locale.ENGLISH_US, title="Locale to be displayed"),
+    locale: Annotated[
+        Locale, Query(title="Locale to be displayed")
+    ] = Locale.ENGLISH_US,
 ) -> list[RoleDetail]:
     return await ListRolesController(request).process_request(locale=locale)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overfast-api"
-version = "3.6.0"
+version = "3.6.1"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = {file = "LICENSE"}
 authors = [
@@ -34,7 +34,7 @@ dev-dependencies = [
     "pytest-cov==6.0.*",
     "pytest-randomly==3.16.*",
     "pytest-xdist==3.6.*",
-    "ruff==0.7.*",
+    "ruff==0.8.*",
     "pre-commit==4.0.*",
     "pyinstrument>=5.0.0",
     "memray>=1.14.0",
@@ -61,6 +61,7 @@ select = [
     "S",     # flake8-bandit
     "BLE",   # flake8-blind-except
     "B",     # flake8-bugbear
+    "A",     # flake8-builtins
     "COM",   # flake8-commas
     "C4",    # flake8-comprehensions
     "DTZ",   # flake8-datetimez
@@ -72,6 +73,7 @@ select = [
     "INT",   # flake8-gettext
     "ISC",   # flake8-implicit-str-concat
     "ICN",   # flake8-import-conventions
+    "LOG",   # flake8-logging
     "G",     # flake8-logging-format
     "INP",   # flake8-no-pep420
     "PIE",   # flake8-pie
@@ -85,7 +87,6 @@ select = [
     "SLOT",  # flake8-slots
     "SIM",   # flake8-simplify
     "TID",   # flake8-tidy-imports
-    "TD",    # flake8-todos
     "TCH",   # flake8-type-checking
     "ARG",   # flake8-unused-arguments
     "PTH",   # flake8-use-pathlib
@@ -94,6 +95,7 @@ select = [
     "PL",    # pylint
     "TRY",   # tryceratops
     "FLY",   # flynt
+    "FAST",  # FastAPI rules
     "PERF",  # perflint
     "FURB",  # refurb
     "RUF",   # ruff-specific rules

--- a/uv.lock
+++ b/uv.lock
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.5.1"
+version = "3.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
@@ -594,7 +594,7 @@ dev = [
     { name = "pytest-cov", specifier = "==6.0.*" },
     { name = "pytest-randomly", specifier = "==3.16.*" },
     { name = "pytest-xdist", specifier = "==3.6.*" },
-    { name = "ruff", specifier = "==0.7.*" },
+    { name = "ruff", specifier = "==0.8.*" },
 ]
 
 [[package]]
@@ -892,27 +892,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.7.3"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/06/09d1276df977eece383d0ed66052fc24ec4550a61f8fbc0a11200e690496/ruff-0.7.3.tar.gz", hash = "sha256:e1d1ba2e40b6e71a61b063354d04be669ab0d39c352461f3d789cac68b54a313", size = 3243664 }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/d6/a2373f3ba7180ddb44420d2a9d1f1510e1a4d162b3d27282bedcb09c8da9/ruff-0.8.0.tar.gz", hash = "sha256:a7ccfe6331bf8c8dad715753e157457faf7351c2b69f62f32c165c2dbcbacd44", size = 3276537 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/56/933d433c2489e4642487b835f53dd9ff015fb3d8fa459b09bb2ce42d7c4b/ruff-0.7.3-py3-none-linux_armv6l.whl", hash = "sha256:34f2339dc22687ec7e7002792d1f50712bf84a13d5152e75712ac08be565d344", size = 10372090 },
-    { url = "https://files.pythonhosted.org/packages/20/ea/1f0a22a6bcdd3fc26c73f63a025d05bd565901b729d56bcb093c722a6c4c/ruff-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fb397332a1879b9764a3455a0bb1087bda876c2db8aca3a3cbb67b3dbce8cda0", size = 10190037 },
-    { url = "https://files.pythonhosted.org/packages/16/74/aca75666e0d481fe394e76a8647c44ea919087748024924baa1a17371e3e/ruff-0.7.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:37d0b619546103274e7f62643d14e1adcbccb242efda4e4bdb9544d7764782e9", size = 9811998 },
-    { url = "https://files.pythonhosted.org/packages/20/a1/cf446a0d7f78ea1f0bd2b9171c11dfe746585c0c4a734b25966121eb4f5d/ruff-0.7.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59f0c3ee4d1a6787614e7135b72e21024875266101142a09a61439cb6e38a5", size = 10620626 },
-    { url = "https://files.pythonhosted.org/packages/cd/c1/82b27d09286ae855f5d03b1ad37cf243f21eb0081732d4d7b0d658d439cb/ruff-0.7.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:44eb93c2499a169d49fafd07bc62ac89b1bc800b197e50ff4633aed212569299", size = 10177598 },
-    { url = "https://files.pythonhosted.org/packages/b9/42/c0acac22753bf74013d035a5ef6c5c4c40ad4d6686bfb3fda7c6f37d9b37/ruff-0.7.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d0242ce53f3a576c35ee32d907475a8d569944c0407f91d207c8af5be5dae4e", size = 11171963 },
-    { url = "https://files.pythonhosted.org/packages/43/18/bb0befb7fb9121dd9009e6a72eb98e24f1bacb07c6f3ecb55f032ba98aed/ruff-0.7.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6b6224af8b5e09772c2ecb8dc9f3f344c1aa48201c7f07e7315367f6dd90ac29", size = 11856157 },
-    { url = "https://files.pythonhosted.org/packages/5e/91/04e98d7d6e32eca9d1372be595f9abc7b7f048795e32eb2edbd8794d50bd/ruff-0.7.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c50f95a82b94421c964fae4c27c0242890a20fe67d203d127e84fbb8013855f5", size = 11440331 },
-    { url = "https://files.pythonhosted.org/packages/f5/dc/3fe99f2ce10b76d389041a1b9f99e7066332e479435d4bebcceea16caff5/ruff-0.7.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f3eff9961b5d2644bcf1616c606e93baa2d6b349e8aa8b035f654df252c8c67", size = 12725354 },
-    { url = "https://files.pythonhosted.org/packages/43/7b/1daa712de1c5bc6cbbf9fa60e9c41cc48cda962dc6d2c4f2a224d2c3007e/ruff-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8963cab06d130c4df2fd52c84e9f10d297826d2e8169ae0c798b6221be1d1d2", size = 11010091 },
-    { url = "https://files.pythonhosted.org/packages/b6/db/1227a903587432eb569e57a95b15a4f191a71fe315cde4c0312df7bc85da/ruff-0.7.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:61b46049d6edc0e4317fb14b33bd693245281a3007288b68a3f5b74a22a0746d", size = 10610687 },
-    { url = "https://files.pythonhosted.org/packages/db/e2/dc41ee90c3085aadad4da614d310d834f641aaafddf3dfbba08210c616ce/ruff-0.7.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10ebce7696afe4644e8c1a23b3cf8c0f2193a310c18387c06e583ae9ef284de2", size = 10254843 },
-    { url = "https://files.pythonhosted.org/packages/6f/09/5f6cac1c91542bc5bd33d40b4c13b637bf64d7bb29e091dadb01b62527fe/ruff-0.7.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3f36d56326b3aef8eeee150b700e519880d1aab92f471eefdef656fd57492aa2", size = 10730962 },
-    { url = "https://files.pythonhosted.org/packages/d3/42/89a4b9a24ef7d00269e24086c417a006f9a3ffeac2c80f2629eb5ce140ee/ruff-0.7.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5d024301109a0007b78d57ab0ba190087b43dce852e552734ebf0b0b85e4fb16", size = 11101907 },
-    { url = "https://files.pythonhosted.org/packages/b0/5c/efdb4777686683a8edce94ffd812783bddcd3d2454d38c5ac193fef7c500/ruff-0.7.3-py3-none-win32.whl", hash = "sha256:4ba81a5f0c5478aa61674c5a2194de8b02652f17addf8dfc40c8937e6e7d79fc", size = 8611095 },
-    { url = "https://files.pythonhosted.org/packages/bb/b8/28fbc6a4efa50178f973972d1c84b2d0a33cdc731588522ab751ac3da2f5/ruff-0.7.3-py3-none-win_amd64.whl", hash = "sha256:588a9ff2fecf01025ed065fe28809cd5a53b43505f48b69a1ac7707b1b7e4088", size = 9418283 },
-    { url = "https://files.pythonhosted.org/packages/3f/77/b587cba6febd5e2003374f37eb89633f79f161e71084f94057c8653b7fb3/ruff-0.7.3-py3-none-win_arm64.whl", hash = "sha256:1713e2c5545863cdbfe2cbce21f69ffaf37b813bfd1fb3b90dc9a6f1963f5a8c", size = 8725228 },
+    { url = "https://files.pythonhosted.org/packages/ec/77/e889ee3ce7fd8baa3ed1b77a03b9fb8ec1be68be1418261522fd6a5405e0/ruff-0.8.0-py3-none-linux_armv6l.whl", hash = "sha256:fcb1bf2cc6706adae9d79c8d86478677e3bbd4ced796ccad106fd4776d395fea", size = 10518283 },
+    { url = "https://files.pythonhosted.org/packages/da/c8/0a47de01edf19fb22f5f9b7964f46a68d0bdff20144d134556ffd1ba9154/ruff-0.8.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:295bb4c02d58ff2ef4378a1870c20af30723013f441c9d1637a008baaf928c8b", size = 10317691 },
+    { url = "https://files.pythonhosted.org/packages/41/17/9885e4a0eeae07abd2a4ebabc3246f556719f24efa477ba2739146c4635a/ruff-0.8.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7b1f1c76b47c18fa92ee78b60d2d20d7e866c55ee603e7d19c1e991fad933a9a", size = 9940999 },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/46b6f7043597eb318b5f5482c8ae8f5491cccce771e85f59d23106f2d179/ruff-0.8.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb0d4f250a7711b67ad513fde67e8870109e5ce590a801c3722580fe98c33a99", size = 10772437 },
+    { url = "https://files.pythonhosted.org/packages/5d/87/afc95aeb8bc78b1d8a3461717a4419c05aa8aa943d4c9cbd441630f85584/ruff-0.8.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e55cce9aa93c5d0d4e3937e47b169035c7e91c8655b0974e61bb79cf398d49c", size = 10299156 },
+    { url = "https://files.pythonhosted.org/packages/65/fa/04c647bb809c4d65e8eae1ed1c654d9481b21dd942e743cd33511687b9f9/ruff-0.8.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f4cd64916d8e732ce6b87f3f5296a8942d285bbbc161acee7fe561134af64f9", size = 11325819 },
+    { url = "https://files.pythonhosted.org/packages/90/26/7dad6e7d833d391a8a1afe4ee70ca6f36c4a297d3cca83ef10e83e9aacf3/ruff-0.8.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c5c1466be2a2ebdf7c5450dd5d980cc87c8ba6976fb82582fea18823da6fa362", size = 12023927 },
+    { url = "https://files.pythonhosted.org/packages/24/a0/be5296dda6428ba8a13bda8d09fbc0e14c810b485478733886e61597ae2b/ruff-0.8.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2dabfd05b96b7b8f2da00d53c514eea842bff83e41e1cceb08ae1966254a51df", size = 11589702 },
+    { url = "https://files.pythonhosted.org/packages/26/3f/7602eb11d2886db545834182a9dbe500b8211fcbc9b4064bf9d358bbbbb4/ruff-0.8.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:facebdfe5a5af6b1588a1d26d170635ead6892d0e314477e80256ef4a8470cf3", size = 12782936 },
+    { url = "https://files.pythonhosted.org/packages/4c/5d/083181bdec4ec92a431c1291d3fff65eef3ded630a4b55eb735000ef5f3b/ruff-0.8.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87a8e86bae0dbd749c815211ca11e3a7bd559b9710746c559ed63106d382bd9c", size = 11138488 },
+    { url = "https://files.pythonhosted.org/packages/b7/23/c12cdef58413cee2436d6a177aa06f7a366ebbca916cf10820706f632459/ruff-0.8.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85e654f0ded7befe2d61eeaf3d3b1e4ef3894469cd664ffa85006c7720f1e4a2", size = 10744474 },
+    { url = "https://files.pythonhosted.org/packages/29/61/a12f3b81520083cd7c5caa24ba61bb99fd1060256482eff0ef04cc5ccd1b/ruff-0.8.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:83a55679c4cb449fa527b8497cadf54f076603cc36779b2170b24f704171ce70", size = 10369029 },
+    { url = "https://files.pythonhosted.org/packages/08/2a/c013f4f3e4a54596c369cee74c24870ed1d534f31a35504908b1fc97017a/ruff-0.8.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:812e2052121634cf13cd6fddf0c1871d0ead1aad40a1a258753c04c18bb71bbd", size = 10867481 },
+    { url = "https://files.pythonhosted.org/packages/d5/f7/685b1e1d42a3e94ceb25eab23c70bdd8c0ab66a43121ef83fe6db5a58756/ruff-0.8.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:780d5d8523c04202184405e60c98d7595bdb498c3c6abba3b6d4cdf2ca2af426", size = 11237117 },
+    { url = "https://files.pythonhosted.org/packages/03/20/401132c0908e8837625e3b7e32df9962e7cd681a4df1e16a10e2a5b4ecda/ruff-0.8.0-py3-none-win32.whl", hash = "sha256:5fdb6efecc3eb60bba5819679466471fd7d13c53487df7248d6e27146e985468", size = 8783511 },
+    { url = "https://files.pythonhosted.org/packages/1d/5c/4d800fca7854f62ad77f2c0d99b4b585f03e2d87a6ec1ecea85543a14a3c/ruff-0.8.0-py3-none-win_amd64.whl", hash = "sha256:582891c57b96228d146725975fbb942e1f30a0c4ba19722e692ca3eb25cc9b4f", size = 9559876 },
+    { url = "https://files.pythonhosted.org/packages/5b/bc/cc8a6a5ca4960b226dc15dd8fb511dd11f2014ff89d325c0b9b9faa9871f/ruff-0.8.0-py3-none-win_arm64.whl", hash = "sha256:ba93e6294e9a737cd726b74b09a6972e36bb511f9a102f1d9a7e1ce94dd206a6", size = 8939733 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Refactor FastAPI route query parameters to use 'Annotated' type for better type hinting. Update ruff to version 0.8.0 and remove sourcery from pre-commit hooks. Bump project version to 3.6.1.

Enhancements:
- Refactor code to use Python's 'Annotated' type for query parameters in FastAPI routes, improving type hinting and readability.

Build:
- Update ruff version to 0.8.0 in pre-commit configuration and pyproject.toml, removing sourcery from pre-commit hooks.

Chores:
- Bump project version from 3.6.0 to 3.6.1 in pyproject.toml.