### PR TITLE
fix: using entire btag with encoded number sign for players search

### DIFF
--- a/app/players/parsers/search_data_parser.py
+++ b/app/players/parsers/search_data_parser.py
@@ -48,7 +48,8 @@ class SearchDataParser(JSONParser, ABC):
         return {self.data_type: data_value}
 
     def get_blizzard_url(self, **kwargs) -> str:
-        player_name = kwargs.get("player_id").split("-")[0]
+        # Replace dash by encoded number sign (#) for search
+        player_name = kwargs.get("player_id").replace("-", "%23")
         return f"{super().get_blizzard_url(**kwargs)}/{player_name}/"
 
     def retrieve_data_value(self, player_data: dict) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overfast-api"
-version = "3.8.1"
+version = "3.8.2"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = {file = "LICENSE"}
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.8.1"
+version = "3.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
If we don't specify the entire battletag to Blizzard when searching for players, sometimes players won't be in search results even if their profile are public. It happens a lot for battletag containing very common nicknames : Arthur, Ace, etc.
The reason on Blizzard side is unknown as there isn't any obvious pagination and number of results differs between different nicknames.

When we specify the entire battletag, the profile can properly be found as expected, this is what this PR is fixing.

## Summary by Sourcery

Use the entire BattleTag, including the number sign, when searching for players to ensure consistent results.

Bug Fixes:
- Fixed an issue where players with common nicknames were not appearing in search results when searching by name only.

Enhancements:
- Updated player search to use encoded number signs (%23) in place of dashes (-) in BattleTags.