### PR TITLE
fix: added proper support for remote protocol error from Blizzard

### DIFF
--- a/app/overfast_client.py
+++ b/app/overfast_client.py
@@ -34,7 +34,7 @@ class OverFastClient(metaclass=Singleton):
         try:
             response = await self.client.get(url)
         except httpx.TimeoutException as error:
-            # Sometimes Blizzard takes to much time to give a response (player profiles, etc.)
+            # Sometimes Blizzard takes too much time to give a response (player profiles, etc.)
             raise self._blizzard_response_error(
                 status_code=0,
                 error="Blizzard took more than 10 seconds to respond, resulting in a timeout",

--- a/app/overfast_client.py
+++ b/app/overfast_client.py
@@ -34,9 +34,16 @@ class OverFastClient(metaclass=Singleton):
         try:
             response = await self.client.get(url)
         except httpx.TimeoutException as error:
+            # Sometimes Blizzard takes to much time to give a response (player profiles, etc.)
             raise self._blizzard_response_error(
                 status_code=0,
                 error="Blizzard took more than 10 seconds to respond, resulting in a timeout",
+            ) from error
+        except httpx.RemoteProtocolError as error:
+            # Sometimes Blizzard sends an invalid response (search players, etc.)
+            raise self._blizzard_response_error(
+                status_code=0,
+                error="Blizzard closed the connection, no data could be retrieved",
             ) from error
 
         logger.debug("OverFast request done !")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overfast-api"
-version = "3.9.3"
+version = "3.9.4"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = {file = "LICENSE"}
 authors = [


### PR DESCRIPTION
## Summary by Sourcery

Handle httpx.RemoteProtocolError exceptions when querying the Blizzard API, returning a 504 Gateway Timeout error to the client.

Bug Fixes:
- Handle RemoteProtocolError exceptions from the Blizzard API, returning a 504 Gateway Timeout error.
- Update the API version to 3.9.4.