### PR TITLE
feat: put back search with battletag

### DIFF
--- a/app/players/router.py
+++ b/app/players/router.py
@@ -102,7 +102,8 @@ router = APIRouter()
     tags=[RouteTag.PLAYERS],
     summary="Search for a specific player",
     description=(
-        "Search for a given player by using its username. Battletags won't work and aren't supported."
+        "Search for a given player by using its username or BattleTag (with # replaced by -). "
+        "If you don't find the player by using the name, please try with the BattleTag. "
         "<br />You should be able to find the associated player_id to use in order to request career data."
         f"<br />**Cache TTL : {SearchPlayersController.get_human_readable_timeout()}.**"
     ),
@@ -114,8 +115,8 @@ async def search_players(
     name: Annotated[
         str,
         Query(
-            title="Player nickname to search",
-            examples=["TeKrop"],
+            title="Player nickname or BattleTag to search",
+            examples=["TeKrop", "TeKrop-2217"],
         ),
     ],
     order_by: Annotated[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overfast-api"
-version = "3.11.2"
+version = "3.11.3"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = {file = "LICENSE"}
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -554,7 +554,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.11.2"
+version = "3.11.3"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
## Summary by Sourcery

Re-enable player search using BattleTags.

New Features:
- Allow searching for players by their BattleTag (using '-' instead of '#').

Enhancements:
- Modify the player search parser to filter results by BattleTag when provided in the search query.
- Update the API documentation for the player search endpoint to reflect BattleTag search capability.
- Update the player search examples to include BattleTags.
- Store the original search nickname in the parser for filtering purposes.
- Use the original search nickname when constructing the Blizzard URL.
- Filter players based on the provided search nickname (BattleTag or username) before applying transformations.
- Pass the filtered list of players to the transformation step.
- Update the parameter description and examples for the player search endpoint in the router.
- Adjust the API endpoint description to clarify that both nicknames and BattleTags (with '-' instead of '#') can be used for searching.
- Update the examples for the 'name' query parameter to include a BattleTag example.
- Bump the project version in pyproject.toml.