### PR TITLE
fix: fixed issue with missing data-hero-id in stats concerning wuyang

### DIFF
--- a/app/players/parsers/player_career_parser.py
+++ b/app/players/parsers/player_career_parser.py
@@ -356,9 +356,16 @@ class PlayerCareerParser(BasePlayerParser):
                 ),
                 "values": [
                     {
-                        "hero": progress_bar_container.first_child.attributes[
-                            "data-hero-id"
-                        ],
+                        # Normally, a valid data-hero-id is present. However, in some
+                        # cases — such as when a hero is newly available for testing —
+                        # stats may lack an associated ID. In these instances, we fall
+                        # back to using the hero's title in lowercase.
+                        "hero": (
+                            progress_bar_container.first_child.attributes.get(
+                                "data-hero-id"
+                            )
+                            or progress_bar_container.last_child.first_child.text().lower()
+                        ),
                         "value": get_computed_stat_value(
                             progress_bar_container.last_child.last_child.text()
                         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overfast-api"
-version = "3.16.0"
+version = "3.16.1"
 description = "Overwatch API giving data about heroes, maps, and players statistics."
 license = {file = "LICENSE"}
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.16.0"
+version = "3.16.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },


### PR DESCRIPTION
## Summary by Sourcery

Use fallback hero title when data-hero-id is missing and update package version to 3.16.1.

Bug Fixes:
- Fallback to hero's title in lowercase when data-hero-id attribute is missing in hero stats.

Build:
- Bump project version to 3.16.1.