### PR TITLE
feat: added new heroes and removed the 2 from game name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This document is intended to be a concise, repository-specific checklist and ref
 
 ## Project overview
 
-OverFast API is a FastAPI-based Overwatch 2 data API that scrapes Blizzard pages to provide data about heroes, game modes, maps, and player statistics. It uses a three-tier caching strategy backed by Valkey, with Nginx/OpenResty as a reverse proxy.
+OverFast API is a FastAPI-based Overwatch data API that scrapes Blizzard pages to provide data about heroes, game modes, maps, and player statistics. It uses a three-tier caching strategy backed by Valkey, with Nginx/OpenResty as a reverse proxy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: MIT](https://img.shields.io/github/license/TeKrop/overfast-api)](https://github.com/TeKrop/overfast-api/blob/master/LICENSE)
 ![Mockup OverFast API](https://files.tekrop.fr/overfast_api_logo_full_1000.png)
 
-> OverFast API provides comprehensive data on Overwatch 2 heroes, game modes, maps, and player statistics by scraping Blizzard pages. Developed with the efficiency of **FastAPI** and **Selectolax**, it leverages **nginx (OpenResty)** as a reverse proxy and **Valkey** for caching. Its tailored caching mechanism significantly reduces calls to Blizzard pages, ensuring swift and precise data delivery to users.
+> OverFast API provides comprehensive data on Overwatch heroes, game modes, maps, and player statistics by scraping Blizzard pages. Developed with the efficiency of **FastAPI** and **Selectolax**, it leverages **nginx (OpenResty)** as a reverse proxy and **Valkey** for caching. Its tailored caching mechanism significantly reduces calls to Blizzard pages, ensuring swift and precise data delivery to users.
 
 ## Table of contents
 * [✨ Live instance](#-live-instance)

--- a/app/heroes/data/heroes.csv
+++ b/app/heroes/data/heroes.csv
@@ -1,18 +1,22 @@
 key,name,role,health,armor,shields
 ana,Ana,support,250,0,0
+anran,Anran,damage,250,0,0
 ashe,Ashe,damage,250,0,0
 baptiste,Baptiste,support,250,0,0
 bastion,Bastion,damage,250,100,0
 brigitte,Brigitte,support,200,50,0
 cassidy,Cassidy,damage,250,0,0
 dva,D.Va,tank,375,325,0
+domina,Domina,tank,525,0,0
 doomfist,Doomfist,tank,525,0,0
 echo,Echo,damage,150,0,75
+emre,Emre,damage,250,0,0
 freja,Freja,damage,225,0,0
 genji,Genji,damage,250,0,0
 hazard,Hazard,tank,425,225,0
 hanzo,Hanzo,damage,250,0,0
 illari,Illari,support,250,0,0
+jetpack-cat,Jetpack Cat,support,250,0,0
 junker-queen,Junker Queen,tank,525,0,0
 junkrat,Junkrat,damage,250,0,0
 juno,Juno,support,75,0,150
@@ -22,6 +26,7 @@ lucio,Lúcio,support,225,0,0
 mauga,Mauga,tank,575,150,0
 mei,Mei,damage,300,0,0
 mercy,Mercy,support,225,0,0
+mizuki,Mizuki,support,225,0,0
 moira,Moira,support,225,0,0
 orisa,Orisa,tank,300,300,0
 pharah,Pharah,damage,225,0,0

--- a/app/main.py
+++ b/app/main.py
@@ -66,7 +66,7 @@ async def lifespan(_: FastAPI):  # pragma: no cover
     await overfast_client.aclose()
 
 
-description = f"""OverFast API provides comprehensive data on Overwatch 2 heroes,
+description = f"""OverFast API provides comprehensive data on Overwatch heroes,
 game modes, maps, and player statistics by scraping Blizzard pages. Developed with
 the efficiency of **FastAPI** and **Selectolax**, it leverages **nginx (OpenResty)** as a
 reverse proxy and **Valkey** for caching. Its tailored caching mechanism significantly


### PR DESCRIPTION
## Summary by Sourcery

Update hero data and align project naming from Overwatch 2 to Overwatch across code and docs.

New Features:
- Extend heroes dataset with additional hero entries in the API data source.

Enhancements:
- Adjust application description metadata to match the updated Overwatch branding.

Documentation:
- Update AGENTS and README descriptions to refer to Overwatch instead of Overwatch 2.