### PR TITLE
fix: forcing en-us versions of player profile pages to be loaded for the API

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -149,10 +149,10 @@ class Settings(BaseSettings):
     heroes_path: str = "/heroes/"
 
     # Route for players career pages
-    career_path: str = "/career"
+    career_path: str = "/en-us/career"
 
     # Route for searching Overwatch accounts by name
-    search_account_path: str = "/search/account-by-name"
+    search_account_path: str = "/en-us/search/account-by-name"
 
     # Route for retrieving usage statistics about Overwatch heroes
     hero_stats_path: str = "/rates/data/"

--- a/app/players/controllers/get_player_career_controller.py
+++ b/app/players/controllers/get_player_career_controller.py
@@ -48,8 +48,8 @@ class GetPlayerCareerController(BasePlayerController):
 
             try:
                 # Get player summary from search endpoint
-                logger.info("Retrieving Player Summary...")
                 player_summary = await parse_player_summary(client, player_id)
+                logger.info("Player Summary retrieved !")
 
                 # If player not found in search, fetch directly with player_id
                 if not player_summary:


### PR DESCRIPTION
## Summary by Sourcery

Update Overwatch player career and account search routes to use en-us localized paths and adjust logging around player summary retrieval.

Bug Fixes:
- Ensure API calls for player career and account search use the en-us versions of the profile pages to correctly retrieve data.

Enhancements:
- Improve logging by confirming when the player summary has been successfully retrieved.