### PR TITLE
fix: fixed issue with missing category names on profile pages sometimes

### DIFF
--- a/app/adapters/blizzard/parsers/player_profile.py
+++ b/app/adapters/blizzard/parsers/player_profile.py
@@ -447,6 +447,14 @@ def _parse_career_stats(career_stats_section: LexborNode) -> dict:
                 category_label
             )
 
+            # Skip if normalization resulted in empty string
+            if not normalized_category_label or not normalized_category_label.strip():
+                logger.warning(
+                    f"Category label normalized to empty for hero {hero_key} "
+                    f"(original: {category_label!r}), skipping"
+                )
+                continue
+
             # Parse all stats for this category
             stats = _parse_category_stats(content_div)
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.30.0"
+version = "3.34.4"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent missing or invalid career stats categories from causing empty category names on player profile pages by skipping categories whose normalized labels are empty.