### PR TITLE
fix(parsers): Correct competitive gamemode mapping

### DIFF
--- a/app/adapters/blizzard/parsers/hero_stats_summary.py
+++ b/app/adapters/blizzard/parsers/hero_stats_summary.py
@@ -20,7 +20,7 @@ PLATFORM_MAPPING: dict[PlayerPlatform, str] = {
 
 GAMEMODE_MAPPING: dict[PlayerGamemode, str] = {
     PlayerGamemode.QUICKPLAY: "0",
-    PlayerGamemode.COMPETITIVE: "1",
+    PlayerGamemode.COMPETITIVE: "2",
 }
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect Blizzard gamemode ID used for competitive hero stats parsing.