### PR TITLE
fix: fixed issue where swagger and redoc were not displaying properly if API is rate limited by Blizzard

### DIFF
--- a/build/nginx/valkey_handler.lua.template
+++ b/build/nginx/valkey_handler.lua.template
@@ -2,8 +2,9 @@ local zstd = require "zstd"
 local valkey = require "resty.redis"
 
 local function handle_valkey_request()
-    -- Root path never has API cache (serves docs), always forward to app
-    if ngx.var.uri == "/" then
+    -- These paths never have API cache, always forward to app
+    local cache_excluded_paths = { ["/"] = true, ["/docs"] = true, ["/openapi.json"] = true }
+    if cache_excluded_paths[ngx.var.uri] then
         ngx.exec("@fallback")
         return
     end


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure Swagger and Redoc documentation pages render correctly when Blizzard API responses are rate limited.