### PR TITLE
Bugfix/sqlite storage usage optimisation

### DIFF
--- a/app/adapters/storage/sqlite_storage.py
+++ b/app/adapters/storage/sqlite_storage.py
@@ -66,13 +66,11 @@ class SQLiteStorage(metaclass=Singleton):
         Get the persistent shared database connection.
         PRAGMAs are set once during initialize(), not on every operation.
         """
+        if self._shared_connection is None:
+            msg = "SQLite connection not initialized. Call initialize() first."
+            raise RuntimeError(msg)
         try:
-            if self._shared_connection is None:
-                msg = "SQLite connection not initialized. Call initialize() first."
-                raise RuntimeError(msg)
             yield self._shared_connection
-        except RuntimeError:
-            raise
         except Exception as e:
             if settings.prometheus_enabled:
                 error_type = type(e).__name__

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.40.0"
+version = "3.41.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary by Sourcery

Use a single persistent SQLite connection configured at initialization and adjust player status lookup to correctly handle battletag vs player_id identifiers.

Bug Fixes:
- Fix player status retrieval to first look up by battletag and then fall back to player_id, ensuring correct results for both identifier types.

Enhancements:
- Refactor SQLite storage to use a single shared connection with PRAGMAs applied once at startup to reduce per-operation overhead and improve performance.
- Clarify SQLite storage documentation to note the use of a persistent connection for configuration reuse.