### PR TITLE
fix(players): use Player Cache as fallback when Blizzard summary is unavailable

### DIFF
--- a/app/players/controllers/get_player_career_controller.py
+++ b/app/players/controllers/get_player_career_controller.py
@@ -155,13 +155,16 @@ class GetPlayerCareerController(BasePlayerController):
             # Case 2: No summary available (e.g. Blizzard rate-limited) — use
             # cached data as fallback so we can still serve a response instead
             # of hitting Blizzard again (which would also fail).
-            if not player_summary and cached_summary:
+            if (
+                not player_summary
+                and isinstance(cached_summary, dict)
+                and cached_summary
+            ):
                 logger.info(
                     "No player summary available, using Player Cache as fallback"
                 )
                 html = cast("str", player_cache["profile"])
-                fallback_summary = cached_summary if isinstance(cached_summary, dict) else {}
-                profile_data = parse_player_profile_html(html, fallback_summary)
+                profile_data = parse_player_profile_html(html, cached_summary)
                 return html, profile_data
 
         # Fetch from Blizzard with Blizzard ID

--- a/app/players/controllers/get_player_career_stats_controller.py
+++ b/app/players/controllers/get_player_career_stats_controller.py
@@ -147,14 +147,17 @@ class GetPlayerCareerStatsController(BasePlayerController):
             # Case 2: No summary available (e.g. Blizzard rate-limited) — use
             # cached data as fallback so we can still serve a response instead
             # of hitting Blizzard again (which would also fail).
-            if not player_summary and cached_summary:
+            if (
+                not player_summary
+                and isinstance(cached_summary, dict)
+                and cached_summary
+            ):
                 logger.info(
                     "No player summary available, using Player Cache as fallback"
                 )
                 html = cast("str", player_cache["profile"])
-                fallback_summary = cached_summary if isinstance(cached_summary, dict) else {}
                 return parse_player_career_stats_from_html(
-                    html, fallback_summary, platform, gamemode, hero
+                    html, cached_summary, platform, gamemode, hero
                 )
 
         # Fetch from Blizzard using Blizzard ID

--- a/app/players/controllers/get_player_stats_summary_controller.py
+++ b/app/players/controllers/get_player_stats_summary_controller.py
@@ -143,14 +143,17 @@ class GetPlayerStatsSummaryController(BasePlayerController):
             # Case 2: No summary available (e.g. Blizzard rate-limited) — use
             # cached data as fallback so we can still serve a response instead
             # of hitting Blizzard again (which would also fail).
-            if not player_summary and cached_summary:
+            if (
+                not player_summary
+                and isinstance(cached_summary, dict)
+                and cached_summary
+            ):
                 logger.info(
                     "No player summary available, using Player Cache as fallback"
                 )
                 html = cast("str", player_cache["profile"])
-                fallback_summary = cached_summary if isinstance(cached_summary, dict) else {}
                 return parse_player_stats_summary_from_html(
-                    html, fallback_summary, gamemode, platform
+                    html, cached_summary, gamemode, platform
                 )
 
         # Fetch from Blizzard using Blizzard ID


### PR DESCRIPTION
## Problem

When a player profile is visited and then immediately visited again, the API can return a 429 error instead of serving cached data. This happens because:

1. The first request to Blizzard's search endpoint may trigger a rate limit (HTTP 403)
2. When `player_summary` is empty (`{}`), the Player Cache validation always fails — the condition requires a non-empty `player_summary` to compare `lastUpdated` timestamps:
   ```python
   if (
       player_cache is not None
       and player_summary  # ← always False when rate-limited
       and player_cache["summary"]["lastUpdated"]
       == player_summary["lastUpdated"]
   ):
   ```
3. The controller then attempts to fetch from Blizzard again, which also fails due to the active rate limit
4. Result: 429 error even though valid cached data exists in SQLite

## Fix

Add a fallback path in all three player controllers: when `player_summary` is empty (e.g. Blizzard rate-limited) but a Player Cache entry exists with a stored summary, serve the cached data instead of re-fetching from Blizzard.

The cache validation now has two cases:
- **Case 1** (existing): Fresh summary available → validate `lastUpdated` match
- **Case 2** (new): No summary available → use cached data as fallback

Applied to:
- `GetPlayerCareerController._fetch_profile_with_cache()`
- `GetPlayerStatsSummaryController._fetch_stats_with_cache()`
- `GetPlayerCareerStatsController._fetch_career_stats_with_cache()`

## Impact

- Previously visited profiles remain accessible during Blizzard rate-limit windows
- No behavior change when Blizzard is reachable (Case 1 still takes priority)
- Reduces unnecessary Blizzard API calls that would fail anyway

## Summary by Sourcery

Serve player data from the local Player Cache when Blizzard responses are unavailable, instead of re-calling the Blizzard APIs.

Bug Fixes:
- Allow player profile, stats summary, and career stats endpoints to fall back to cached data when the Blizzard summary is missing or rate-limited, avoiding erroneous 429 responses for recently visited profiles.

Enhancements:
- Relax cache validation in player controllers to use stored summaries when fresh Blizzard summaries are not available, reducing unnecessary external API calls.