### PR TITLE
fix(parsers): add null checks for optional HTML sections in player profile

### DIFF
--- a/app/adapters/blizzard/parsers/player_profile.py
+++ b/app/adapters/blizzard/parsers/player_profile.py
@@ -278,6 +278,9 @@ def _get_last_season_played(root_tag: LexborNode, platform_class: str) -> int | 
         return None
 
     statistics_section = profile_section.css_first("blz-section.stats.competitive-view")
+    if not statistics_section:
+        return None
+
     last_season_played = statistics_section.attributes.get(
         "data-latestherostatrankseasonow2"
     )
@@ -338,7 +341,7 @@ def _parse_gamemode_stats(
     )
 
     # Check if we have a select element (indicates data exists)
-    if not top_heroes_section.css_first("select"):
+    if not top_heroes_section or not top_heroes_section.css_first("select"):
         return None
 
     career_stats_section = statistics_section.css_first(


### PR DESCRIPTION
## Problem

Two functions in `player_profile.py` dereference results from `css_first()` without null checks, causing `AttributeError` crashes when the expected HTML elements are missing:

1. **`_get_last_season_played`** (line 280): `statistics_section.attributes.get(...)` crashes when a player has no competitive stats section (`blz-section.stats.competitive-view` not found).

2. **`_parse_gamemode_stats`** (line 341): `top_heroes_section.css_first("select")` crashes when the gamemode div is missing from the HTML structure.

## Fix

Add null guards so both functions gracefully return `None` instead of crashing:

- `_get_last_season_played`: check `if not statistics_section` before accessing `.attributes`
- `_parse_gamemode_stats`: add `not top_heroes_section` to existing condition before accessing `.css_first()`

## Impact

Prevents crashes for players with incomplete or missing competitive stats sections. No behavior change for players with complete profiles.

## Summary by Sourcery

Prevent player profile parsing from crashing when optional competitive stats sections are missing in the HTML.

Bug Fixes:
- Handle missing competitive statistics section when determining the last season played so the parser returns None instead of raising an AttributeError.
- Guard gamemode stats parsing against absent top heroes sections so missing HTML no longer causes crashes.