### PR TITLE
fix(player): validate discriminator when matching player from search results

### DIFF
--- a/app/adapters/blizzard/parsers/utils.py
+++ b/app/adapters/blizzard/parsers/utils.py
@@ -1,6 +1,5 @@
 """Common utilities for Blizzard HTML/JSON parsing"""
 
-import re
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
@@ -142,27 +141,6 @@ def is_blizzard_id(player_id: str) -> bool:
     """
     # Blizzard IDs contain pipe (| or %7C), BattleTags have format Name-12345
     return ("%7C" in player_id or "|" in player_id) and "-" not in player_id
-
-
-def is_battletag_id(player_id: str) -> bool:
-    """
-    Check if a player_id is a BattleTag with a discriminator (e.g. "Name-12345").
-
-    Args:
-        player_id: Player identifier to check
-
-    Returns:
-        True if player_id is in BattleTag format with a discriminator
-
-    Examples:
-        >>> is_battletag_id("TeKrop-2217")
-        True
-        >>> is_battletag_id("Player")
-        False
-        >>> is_battletag_id("df51a381fe20caf8baa7%7C0bf3b4c47cbebe84b8db9c676a4e9c1f")
-        False
-    """
-    return bool(re.fullmatch(r".+-\d{4,5}", player_id))
 
 
 def match_player_by_blizzard_id(

--- a/uv.lock
+++ b/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "3.44.2"
+version = "3.45.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fixes #382 — API returns wrong profile when Blizzard's search endpoint returns a different player with the same name.

### Root cause

`parse_player_summary_json` matched players by name only. When only **one** public player with that name existed in the search results, the code returned it unconditionally — without verifying that the discriminator (the numeric suffix in the BattleTag, e.g. `2749` in `Progresso-2749`) also matched.

**Concrete scenario from the bug report:**
1. User requests `/players/Progresso-2749`
2. Blizzard's search for `Progresso` returns **one** public result — a *different* Progresso with a distinct Blizzard ID
3. The API accepted that single match and returned the wrong player's profile

A second gap existed when `blizzard_id` was provided (from a cached lookup or Blizzard redirect): the Blizzard ID verification was skipped whenever only **one** name match existed, meaning a wrong single result could still slip through.

### Fix

**`app/adapters/blizzard/parsers/player_summary.py`** — `parse_player_summary_json`:

- When `blizzard_id` is provided, **always** use it to verify the match via `match_player_by_blizzard_id`, regardless of how many name-matches exist.
- When no `blizzard_id` is provided and exactly one name-match is found:
  - If the result URL is a **BattleTag** (`Name-XXXX`): verify `player["url"] == player_id`. Return `{}` if they differ (wrong player).
  - If the result URL is a **Blizzard ID** (hex with `|`/`%7C`): return `{}` — the discriminator cannot be verified without a redirect. The caller's existing redirect-based identity resolution handles this correctly with no observable regression (just one extra redirect request for that edge case).

### Test plan

- [x] New test file `tests/parsers/test_player_summary.py` with 11 targeted unit tests covering all discriminator-validation scenarios
- [x] All 461 existing tests continue to pass
- [x] ruff, ty & pytest CI checks pass

## Summary by Sourcery

Strengthen player search result matching to prevent returning the wrong profile when multiple players share the same name, especially for BattleTags with discriminators.

Bug Fixes:
- Prevent incorrect player profiles being returned when Blizzard search yields a different player sharing the same name but a different discriminator or Blizzard ID.
- Ensure Blizzard ID is always validated against search results when provided, even if there is only a single name match.
- Avoid accepting unverifiable single search results that only expose a Blizzard ID when a BattleTag with discriminator was requested.

Enhancements:
- Introduce a BattleTag identifier helper to distinguish BattleTag-based IDs from Blizzard IDs in parser utilities.

Tests:
- Add a comprehensive test suite for player summary parsing covering discriminator validation, Blizzard ID resolution, ambiguity handling, and malformed payloads.