### PR TITLE
fix: fix invalid gamemode id again for hero stats

### DIFF
--- a/app/domain/parsers/hero_stats_summary.py
+++ b/app/domain/parsers/hero_stats_summary.py
@@ -20,7 +20,7 @@ PLATFORM_MAPPING: dict[PlayerPlatform, str] = {
 
 GAMEMODE_MAPPING: dict[PlayerGamemode, str] = {
     PlayerGamemode.QUICKPLAY: "0",
-    PlayerGamemode.COMPETITIVE: "2",
+    PlayerGamemode.COMPETITIVE: "1",
 }
 
 


### PR DESCRIPTION
Blizzard changed the id again for Competitive data. As they're not returning any error when the input is invalid, it hasn't been detected. I changed the id again so it works fine.

## Summary by Sourcery

Bug Fixes:
- Correct the Competitive gamemode ID mapping in hero stats summary parsing so Competitive data is retrieved properly.