### PR TITLE
Update Postgres mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-overfast}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-overfast}
     volumes:
-      - pg-data:/var/lib/postgresql/data
+      - pg-data:/var/lib/postgresql
     healthcheck:
       test:
         [


### PR DESCRIPTION
Postgres 18 changed its data directory layout. The old volume path causes startup failures even on fresh installs. This updates the mount point to the new expected location so containers start correctly.

### Previous behaviour (fresh install, fresh volumes, etc)
Errors with the following
```
Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" (specifically, using major-version-specific directory names). This better reflects how PostgreSQL itself works, and how upgrades are to be performed. See also https://github.com/docker-library/postgres/pull/1259 Counter to that, there appears to be PostgreSQL data in: /var/lib/postgresql/data (unused mount/volume) This is usually the result of upgrading the Docker image without upgrading the underlying database using "pg_upgrade" (which requires both versions). The suggested container configuration for 18+ is to place a single mount at /var/lib/postgresql which will then place PostgreSQL data in a subdirectory, allowing usage of "pg_upgrade --link" without mount point boundary issues. See https://github.com/docker-library/postgres/issues/37 for a (long) discussion around this process, and suggestions for how to do so.
```

## Summary by Sourcery

Build:
- Change the Postgres Docker Compose volume mount from /var/lib/postgresql/data to /var/lib/postgresql to align with the new Postgres 18 data directory layout.