### PR TITLE
build: added just/make startup checks in CI

### DIFF
--- a/.github/workflows/ci-startup-check.yml
+++ b/.github/workflows/ci-startup-check.yml
@@ -1,0 +1,66 @@
+name: Startup Sanity Check
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  startup-check-just:
+    name: Startup Test (just)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install just
+        run: |
+          sudo apt update
+          sudo apt install -y just
+
+      - name: Prepare environment file
+        run: cp .env.dist .env
+
+      - name: Build and start with monitoring stack (just)
+        run: just up_monitoring
+
+      - name: Check container health (just)
+        run: |
+          docker ps
+          unhealthy=$(docker ps --filter 'health=unhealthy' -q)
+          if [ -n "$unhealthy" ]; then
+            echo "Unhealthy containers detected!"; exit 1
+          fi
+
+      - name: Tear down containers (just)
+        run: just down
+
+  startup-check-make:
+    name: Startup Test (make)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install make
+        run: |
+          sudo apt update
+          sudo apt install -y make
+
+      - name: Prepare environment file
+        run: cp .env.dist .env
+
+      - name: Build and start with monitoring stack (make)
+        run: make up_monitoring
+
+      - name: Check container health (make)
+        run: |
+          docker ps
+          unhealthy=$(docker ps --filter 'health=unhealthy' -q)
+          if [ -n "$unhealthy" ]; then
+            echo "Unhealthy containers detected!"; exit 1
+          fi
+
+      - name: Tear down containers (make)
+        run: make down

--- a/.github/workflows/ci-startup-check.yml
+++ b/.github/workflows/ci-startup-check.yml
@@ -2,65 +2,52 @@ name: Startup Sanity Check
 
 on:
   push:
-    branches: ["main"]
+    branches: [main]
   pull_request:
-    branches: ["main"]
+    branches: [main]
 
 jobs:
-  startup-check-just:
-    name: Startup Test (just)
+  startup-check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tool: [just, make]
+        mode: [up, up_monitoring]
+    name: Startup Test (${{ matrix.tool }} ${{ matrix.mode }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install just
+      - name: Install ${{ matrix.tool }}
         run: |
           sudo apt update
-          sudo apt install -y just
+          sudo apt install -y ${{ matrix.tool }}
 
       - name: Prepare environment file
         run: cp .env.dist .env
 
-      - name: Build and start with monitoring stack (just)
-        run: just up_monitoring
+      - name: Build and start stack
+        run: ${{ matrix.tool }} ${{ matrix.mode }}
 
-      - name: Check container health (just)
+      - name: Wait for all containers to be healthy
         run: |
-          docker ps
+          tries=0
+          max=24
+          while [ "$(docker ps --filter health=starting --format '{{.ID}}' | wc -l)" -gt 0 ]; do
+            tries=$((tries+1))
+            if [ "$tries" -ge "$max" ]; then
+              echo "Timed out waiting for healthy containers" >&2
+              docker ps
+              exit 1
+            fi
+            sleep 5
+          done
           unhealthy=$(docker ps --filter 'health=unhealthy' -q)
           if [ -n "$unhealthy" ]; then
-            echo "Unhealthy containers detected!"; exit 1
+            echo "Unhealthy containers detected!" >&2
+            docker ps
+            exit 1
           fi
 
-      - name: Tear down containers (just)
-        run: just down
-
-  startup-check-make:
-    name: Startup Test (make)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install make
-        run: |
-          sudo apt update
-          sudo apt install -y make
-
-      - name: Prepare environment file
-        run: cp .env.dist .env
-
-      - name: Build and start with monitoring stack (make)
-        run: make up_monitoring
-
-      - name: Check container health (make)
-        run: |
-          docker ps
-          unhealthy=$(docker ps --filter 'health=unhealthy' -q)
-          if [ -n "$unhealthy" ]; then
-            echo "Unhealthy containers detected!"; exit 1
-          fi
-
-      - name: Tear down containers (make)
-        run: make down
+      - name: Tear down containers
+        run: ${{ matrix.tool }} down

--- a/uv.lock
+++ b/uv.lock
@@ -792,7 +792,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "4.1.1"
+version = "4.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary by Sourcery

Add CI workflow to sanity-check project startup using both just and make commands.

CI:
- Introduce a GitHub Actions workflow that builds, starts, health-checks, and tears down the monitoring stack using just-based commands.
- Add a parallel GitHub Actions job that performs the same startup and health checks using make-based commands.