### PR TITLE
fix: fixed issue with server error not properly handled by some endpoints

### DIFF
--- a/app/domain/parsers/hero_stats_summary.py
+++ b/app/domain/parsers/hero_stats_summary.py
@@ -6,7 +6,7 @@ from fastapi import status
 
 from app.config import settings
 from app.domain.enums import PlayerGamemode, PlayerPlatform, PlayerRegion
-from app.domain.exceptions import ParserBlizzardError
+from app.domain.exceptions import ParserBlizzardError, ParserParsingError
 from app.domain.parsers.utils import validate_response_status
 
 if TYPE_CHECKING:
@@ -81,33 +81,43 @@ def parse_hero_stats_json(
     Raises:
         ParserBlizzardError: If map doesn't match gamemode
     """
-    # Blizzard now wraps the payload under a top-level "rates" object;
-    # the previous "selected" and "rates" keys live inside it.
-    rates_payload = json_data["rates"]
+    # Extract top-level structure; raise ParserParsingError on unexpected shape.
+    try:
+        # Blizzard now wraps the payload under a top-level "rates" object;
+        # the previous "selected" and "rates" keys live inside it.
+        rates_payload = json_data["rates"]
+        selected_map = rates_payload["selected"]["map"]
+        rates = rates_payload["rates"]
+    except (KeyError, TypeError) as error:
+        msg = f"Unexpected Blizzard hero stats JSON structure: {error!r}"
+        raise ParserParsingError(msg) from error
 
-    # Validate map matches gamemode
-    if map_filter != rates_payload["selected"]["map"]:
+    # Validate map matches gamemode (outside try so this is never caught above).
+    if map_filter != selected_map:
         raise ParserBlizzardError(
             status_code=status.HTTP_400_BAD_REQUEST,
             message=f"Selected map '{map_filter}' is not compatible with '{gamemode}' gamemode.",
         )
 
-    # Filter by role if provided
-    hero_stats = [
-        rate
-        for rate in rates_payload["rates"]
-        if role_filter is None or rate["hero"]["role"].lower() == role_filter
-    ]
-
-    # Transform to simplified format
-    hero_stats = [
-        {
-            "hero": rate["id"],
-            "pickrate": _normalize_rate(rate["cells"]["pickrate"]),
-            "winrate": _normalize_rate(rate["cells"]["winrate"]),
-        }
-        for rate in hero_stats
-    ]
+    # Filter by role and transform to simplified format; raise ParserParsingError on
+    # unexpected per-entry shape.
+    try:
+        hero_stats = [
+            rate
+            for rate in rates
+            if role_filter is None or rate["hero"]["role"].lower() == role_filter
+        ]
+        hero_stats = [
+            {
+                "hero": rate["id"],
+                "pickrate": _normalize_rate(rate["cells"]["pickrate"]),
+                "winrate": _normalize_rate(rate["cells"]["winrate"]),
+            }
+            for rate in hero_stats
+        ]
+    except (KeyError, TypeError) as error:
+        msg = f"Unexpected Blizzard hero stats JSON structure: {error!r}"
+        raise ParserParsingError(msg) from error
 
     # Apply ordering
     order_field, order_arrangement = order_by.split(":")

--- a/app/domain/services/hero_service.py
+++ b/app/domain/services/hero_service.py
@@ -53,10 +53,19 @@ class HeroService(StaticDataService):
         async def _fetch() -> str:
             return await fetch_heroes_html(self.blizzard_client, locale)
 
+        def _parse(html: str) -> list[dict]:
+            try:
+                return parse_heroes_html(html)
+            except ParserParsingError as exc:
+                blizzard_url = (
+                    f"{settings.blizzard_host}/{locale}{settings.heroes_path}"
+                )
+                raise ParserInternalError(blizzard_url, exc) from exc
+
         return StaticFetchConfig(
             storage_key=f"heroes:{locale}",
             fetcher=_fetch,
-            parser=parse_heroes_html,
+            parser=_parse,
             result_filter=(
                 (lambda data: filter_heroes(data, role, gamemode))
                 if (role or gamemode)
@@ -213,6 +222,9 @@ class HeroService(StaticDataService):
             raise HTTPException(
                 status_code=exc.status_code, detail=exc.message
             ) from exc
+        except ParserParsingError as exc:
+            blizzard_url = f"{settings.blizzard_host}{settings.hero_stats_path}"
+            raise ParserInternalError(blizzard_url, exc) from exc
 
         await self._update_api_cache(
             cache_key,

--- a/tests/heroes/parsers/test_hero_stats_summary.py
+++ b/tests/heroes/parsers/test_hero_stats_summary.py
@@ -9,10 +9,11 @@ from app.domain.enums import (
     PlayerPlatform,
     PlayerRegion,
 )
-from app.domain.exceptions import ParserBlizzardError
+from app.domain.exceptions import ParserBlizzardError, ParserParsingError
 from app.domain.parsers.hero_stats_summary import (
     GAMEMODE_MAPPING,
     PLATFORM_MAPPING,
+    parse_hero_stats_json,
     parse_hero_stats_summary,
 )
 
@@ -106,3 +107,23 @@ async def test_parse_hero_stats_summary_invalid_map_error_message(
 
     assert "hanaoka" in exc_info.value.message
     assert "compatible" in exc_info.value.message.lower()
+
+
+@pytest.mark.parametrize(
+    "json_data",
+    [
+        {},
+        {"rates": None},
+        {"rates": {"selected": {}, "rates": []}},
+        {"rates": {"selected": {"map": "all-maps"}, "rates": [{"id": "ana"}]}},
+    ],
+)
+def test_parse_hero_stats_json_raises_parsing_error_on_unexpected_structure(
+    json_data: dict,
+):
+    with pytest.raises(ParserParsingError):
+        parse_hero_stats_json(
+            json_data,
+            map_filter="all-maps",
+            gamemode=PlayerGamemode.QUICKPLAY,
+        )

--- a/tests/heroes/services/test_hero_service.py
+++ b/tests/heroes/services/test_hero_service.py
@@ -1,8 +1,65 @@
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.domain.services.hero_service import dict_insert_value_before_key
+from app.domain.enums import Locale, PlayerGamemode, PlayerPlatform, PlayerRegion
+from app.domain.exceptions import ParserInternalError, ParserParsingError
+from app.domain.services.hero_service import HeroService, dict_insert_value_before_key
+
+
+def _make_hero_service() -> HeroService:
+    cache = AsyncMock()
+    storage = AsyncMock()
+    blizzard_client = AsyncMock()
+    task_queue = AsyncMock()
+    task_queue.is_job_pending_or_running.return_value = False
+    return HeroService(cache, storage, blizzard_client, task_queue)
+
+
+class TestHeroServiceListHeroesParseError:
+    def test_parse_raises_parser_internal_error_on_parser_parsing_error(self):
+        svc = _make_hero_service()
+        config = svc._heroes_list_config(Locale.ENGLISH_US, "/heroes")
+        parser = config.parser
+        assert parser is not None
+
+        with (
+            patch(
+                "app.domain.services.hero_service.parse_heroes_html",
+                side_effect=ParserParsingError("bad HTML"),
+            ),
+            pytest.raises(ParserInternalError) as exc_info,
+        ):
+            parser("<bad-html>")
+
+        assert str(Locale.ENGLISH_US) in exc_info.value.blizzard_url
+
+
+class TestHeroServiceGetHeroStatsParseError:
+    @pytest.mark.asyncio
+    async def test_get_hero_stats_raises_parser_internal_error_on_parser_parsing_error(
+        self,
+    ):
+        svc = _make_hero_service()
+
+        with (
+            patch(
+                "app.domain.services.hero_service.parse_hero_stats_summary",
+                side_effect=ParserParsingError("unexpected JSON"),
+            ),
+            pytest.raises(ParserInternalError),
+        ):
+            await svc.get_hero_stats(
+                platform=PlayerPlatform.PC,
+                gamemode=PlayerGamemode.QUICKPLAY,
+                region=PlayerRegion.EUROPE,
+                role=None,
+                map_filter=None,
+                competitive_division=None,
+                order_by="hero:asc",
+                cache_key="/heroes/stats",
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/heroes/test_hero_stats_route.py
+++ b/tests/heroes/test_hero_stats_route.py
@@ -12,6 +12,7 @@ from app.domain.enums import (
     PlayerRegion,
     Role,
 )
+from app.domain.exceptions import ParserInternalError, ParserParsingError
 
 if TYPE_CHECKING:
     from fastapi.testclient import TestClient
@@ -244,3 +245,17 @@ def test_get_hero_stats_blizzard_forbidden_error_and_caching(client: TestClient)
         "Blizzard is temporarily rate limiting this API. Please retry after"
         in response1.json()["error"]
     )
+
+
+def test_get_hero_stats_parser_parsing_error(client: TestClient):
+    cause = ParserParsingError("unexpected JSON structure")
+    with patch(
+        "app.domain.services.hero_service.HeroService.get_hero_stats",
+        side_effect=ParserInternalError(
+            "https://overwatch.blizzard.com/en-us/rates/data/", cause
+        ),
+    ):
+        response = client.get("/heroes/stats", params=_BASE_PARAMS)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json() == {"error": settings.internal_server_error_message}

--- a/tests/heroes/test_heroes_route.py
+++ b/tests/heroes/test_heroes_route.py
@@ -6,6 +6,7 @@ from fastapi import status
 
 from app.config import settings
 from app.domain.enums import HeroGamemode, Role
+from app.domain.exceptions import ParserInternalError, ParserParsingError
 
 if TYPE_CHECKING:
     from fastapi.testclient import TestClient
@@ -97,3 +98,17 @@ def test_get_heroes_blizzard_forbidden_error(client: TestClient):
         "Blizzard is temporarily rate limiting this API. Please retry after"
         in response.json()["error"]
     )
+
+
+def test_get_heroes_parser_parsing_error(client: TestClient):
+    cause = ParserParsingError("unexpected HTML structure")
+    with patch(
+        "app.domain.services.hero_service.HeroService.list_heroes",
+        side_effect=ParserInternalError(
+            "https://overwatch.blizzard.com/heroes/", cause
+        ),
+    ):
+        response = client.get("/heroes")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json() == {"error": settings.internal_server_error_message}

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "4.4.0"
+version = "4.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary by Sourcery

Handle parser-level failures from Blizzard hero endpoints as internal errors and ensure they surface as generic 500 responses to clients.

Bug Fixes:
- Convert hero stats JSON structural mismatches into ParserParsingError so they are wrapped as ParserInternalError and returned as 500s.
- Wrap heroes list HTML parsing failures in ParserInternalError and verify the route returns a 500 with a generic error message.
- Ensure hero stats and heroes routes correctly map parser parsing failures to internal server error responses instead of leaking implementation details.

Enhancements:
- Add HeroService unit coverage for parser error handling in heroes list and hero stats operations, including propagation of Blizzard URLs.
- Expand hero stats summary parser tests to cover unexpected JSON structures that should be treated as parsing errors.

Tests:
- Add service-level tests for HeroService heroes list and hero stats behavior when underlying parsers raise ParserParsingError.
- Add API route tests verifying heroes and hero stats endpoints return HTTP 500 with a generic error message on parser-originated internal errors.
- Extend hero stats summary parser tests to validate ParserParsingError is raised for malformed or unexpected Blizzard payloads.