### PR TITLE
fix: adjusted human readable duration on doc cache TTL while under one minute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dump.rdb
 
 # ruff related folders
 .ruff_*/
+
+# AI Agents
+.opencode

--- a/app/api/helpers.py
+++ b/app/api/helpers.py
@@ -123,6 +123,9 @@ def get_human_readable_duration(duration: int) -> str:
     if minutes > 0:
         duration_parts.append(f"{minutes} minute{'s' if minutes > 1 else ''}")
 
+    if not duration_parts:
+        return "less than a minute"
+
     return ", ".join(duration_parts)
 
 

--- a/openspec/changes/archive/2026-06-07-fix-human-readable-duration/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-fix-human-readable-duration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-fix-human-readable-duration/design.md
+++ b/openspec/changes/archive/2026-06-07-fix-human-readable-duration/design.md
@@ -1,0 +1,33 @@
+## Context
+
+`get_human_readable_duration` is a `@cache`-decorated helper used in every router's
+route description to display the cache TTL in human-readable form. It currently
+produces an empty string for any duration under 60 seconds, resulting in malformed
+documentation strings like `"Cache TTL : ."`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure the function always returns a non-empty string for any non-negative integer input
+- Keep the fix minimal and non-breaking for all existing call sites
+
+**Non-Goals:**
+- Handling negative durations (not a valid input in this domain)
+- Displaying seconds granularity for durations ≥ 60 seconds
+
+## Decisions
+
+### Decision: Use `"less than a minute"` as the sub-minute fallback
+
+A `"0 minutes"` or `"30 seconds"` fallback would be technically accurate but
+inconsistent with the natural-language style of the existing output (`"1 day"`,
+`"2 hours"`, `"10 minutes"`). `"less than a minute"` matches that register and
+is the conventional phrasing used by tools like git and GitHub.
+
+The fallback is placed as a post-loop guard (`if not duration_parts`) rather than
+a pre-check, keeping the existing logic untouched.
+
+## Risks / Trade-offs
+
+- No risk of breaking existing behavior — the fallback branch is only reached when
+  `duration_parts` is empty, which was previously the silent-empty-string case.

--- a/openspec/changes/archive/2026-06-07-fix-human-readable-duration/proposal.md
+++ b/openspec/changes/archive/2026-06-07-fix-human-readable-duration/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+`get_human_readable_duration` returns an empty string for durations under 60 seconds, causing route description strings across all routers to render as `"Cache TTL : ."` — broken API documentation silently shipped to users.
+
+## What Changes
+
+- Add a `"less than a minute"` fallback when no time unit parts are produced
+- Add a parametrized test case covering `duration < 60`
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `human-readable-duration`: `get_human_readable_duration` now returns a non-empty string for all non-negative integer inputs, including sub-minute durations
+
+## Impact
+
+- `app/api/helpers.py`: Add fallback branch in `get_human_readable_duration`
+- `tests/infrastructure/test_helpers.py`: Add one parametrize entry for `duration=30`

--- a/openspec/changes/archive/2026-06-07-fix-human-readable-duration/specs/human-readable-duration/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-human-readable-duration/specs/human-readable-duration/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Human-readable duration formatting
+`get_human_readable_duration` SHALL convert a non-negative integer number of seconds
+into a human-readable string. The string SHALL be non-empty for all valid inputs,
+including durations under 60 seconds.
+
+#### Scenario: Duration of zero or sub-minute value
+- **WHEN** `get_human_readable_duration` is called with a duration less than 60 seconds
+- **THEN** it returns `"less than a minute"`
+
+#### Scenario: Duration of exactly one minute
+- **WHEN** `get_human_readable_duration` is called with `duration=60`
+- **THEN** it returns `"1 minute"`
+
+#### Scenario: Duration spanning multiple units
+- **WHEN** `get_human_readable_duration` is called with a duration covering days, hours, and minutes
+- **THEN** it returns a comma-separated string of each non-zero unit (e.g. `"1 day, 3 hours, 26 minutes"`)

--- a/openspec/changes/archive/2026-06-07-fix-human-readable-duration/tasks.md
+++ b/openspec/changes/archive/2026-06-07-fix-human-readable-duration/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] 1.1 Add `"less than a minute"` fallback to `get_human_readable_duration` in `app/api/helpers.py`
+
+## 2. Tests
+
+- [x] 2.1 Add parametrize case `(30, "less than a minute")` to `test_get_human_readable_duration` in `tests/infrastructure/test_helpers.py`
+
+## 3. Verify
+
+- [x] 3.1 Run `just check` — type checker passes
+- [x] 3.2 Run `just lint` — no lint errors
+- [x] 3.3 Run `just test tests/infrastructure/test_helpers.py` — all tests pass

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/human-readable-duration/spec.md
+++ b/openspec/specs/human-readable-duration/spec.md
@@ -1,0 +1,22 @@
+# human-readable-duration Specification
+
+## Purpose
+TBD - created by archiving change fix-human-readable-duration. Update Purpose after archive.
+## Requirements
+### Requirement: Human-readable duration formatting
+`get_human_readable_duration` SHALL convert a non-negative integer number of seconds
+into a human-readable string. The string SHALL be non-empty for all valid inputs,
+including durations under 60 seconds.
+
+#### Scenario: Duration of zero or sub-minute value
+- **WHEN** `get_human_readable_duration` is called with a duration less than 60 seconds
+- **THEN** it returns `"less than a minute"`
+
+#### Scenario: Duration of exactly one minute
+- **WHEN** `get_human_readable_duration` is called with `duration=60`
+- **THEN** it returns `"1 minute"`
+
+#### Scenario: Duration spanning multiple units
+- **WHEN** `get_human_readable_duration` is called with a duration covering days, hours, and minutes
+- **THEN** it returns a comma-separated string of each non-zero unit (e.g. `"1 day, 3 hours, 26 minutes"`)
+

--- a/tests/infrastructure/test_helpers.py
+++ b/tests/infrastructure/test_helpers.py
@@ -24,6 +24,7 @@ from app.infrastructure.helpers import (
         (3600, "1 hour"),
         (600, "10 minutes"),
         (60, "1 minute"),
+        (30, "less than a minute"),
     ],
 )
 def test_get_human_readable_duration(input_duration: int, result: str):


### PR DESCRIPTION
- Adjusted human readable duration on doc cache TTL while under one minute
- Added OpenSpec initial configuration and used it for the fix

## Summary by Sourcery

Ensure doc cache TTL durations under one minute render as meaningful text and introduce OpenSpec artifacts to capture the new behavior.

Bug Fixes:
- Return a non-empty human-readable string ("less than a minute") for cache durations under 60 seconds to avoid malformed documentation output.

Enhancements:
- Add OpenSpec configuration, archived change documents, and a human-readable-duration specification to formalize requirements for duration formatting.

Tests:
- Extend helper tests with a case covering sub-minute durations to validate the new fallback behavior.