### PR TITLE
fix: fixed heroes stat competitive filtering again

### DIFF
--- a/app/domain/parsers/hero_stats_summary.py
+++ b/app/domain/parsers/hero_stats_summary.py
@@ -20,7 +20,7 @@ PLATFORM_MAPPING: dict[PlayerPlatform, str] = {
 
 GAMEMODE_MAPPING: dict[PlayerGamemode, str] = {
     PlayerGamemode.QUICKPLAY: "0",
-    PlayerGamemode.COMPETITIVE: "2",
+    PlayerGamemode.COMPETITIVE: "1",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "4.4.3"
+version = "4.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Blizzard changed their filtering parameter value for competitive again. Making this hotfix, and I'll make a definitive bugfix right after.

## Summary by Sourcery

Bug Fixes:
- Correct competitive hero stats filtering by mapping the competitive game mode to the updated parameter value.