### PR TITLE
feat: added caching mechanism for gamemode filter value

### DIFF
--- a/app/adapters/cache/valkey_cache.py
+++ b/app/adapters/cache/valkey_cache.py
@@ -240,6 +240,19 @@ class ValkeyCache(metaclass=Singleton):
             )
         await self.valkey_server.delete(*keys_to_delete)
 
+    @handle_valkey_error(default_return=None)
+    async def get_gamemode_filter(self, gamemode: str) -> str | None:
+        """Return the cached working Blizzard filter string for gamemode, or None."""
+        key = f"{settings.gamemode_filter_key_prefix}:{gamemode}"
+        value = await self.valkey_server.get(key)
+        return value.decode("utf-8") if value else None
+
+    @handle_valkey_error(default_return=None)
+    async def set_gamemode_filter(self, gamemode: str, filter_value: str) -> None:
+        """Persist the working Blizzard filter string for gamemode with no TTL."""
+        key = f"{settings.gamemode_filter_key_prefix}:{gamemode}"
+        await self.valkey_server.set(key, filter_value.encode("utf-8"))
+
     @handle_valkey_error(default_return=[])
     async def scan_keys(self, pattern: str) -> list[str]:
         """Return all Valkey keys matching *pattern* using SCAN iteration."""

--- a/app/config.py
+++ b/app/config.py
@@ -204,6 +204,9 @@ class Settings(BaseSettings):
     # Prefix for Valkey keys storing persistent check count (no TTL, survives cooldown expiry)
     unknown_player_status_key_prefix: str = "unknown-player:status"
 
+    # Prefix for Valkey keys caching the working Blizzard gamemode filter value per gamemode
+    gamemode_filter_key_prefix: str = "gamemode-filter"
+
     ############
     # BACKGROUND WORKER
     ############

--- a/app/domain/ports/cache.py
+++ b/app/domain/ports/cache.py
@@ -108,6 +108,14 @@ class CachePort(Protocol):
         """Delete the tracking status and all associated entries for a player."""
         ...
 
+    async def get_gamemode_filter(self, gamemode: str) -> str | None:
+        """Return the last known-working Blizzard filter value for gamemode, or None."""
+        ...
+
+    async def set_gamemode_filter(self, gamemode: str, filter_value: str) -> None:
+        """Persist the working Blizzard filter value for gamemode with no TTL."""
+        ...
+
     async def scan_keys(self, pattern: str) -> list[str]:
         """Return all cache keys matching the given glob pattern.
 

--- a/app/domain/services/hero_service.py
+++ b/app/domain/services/hero_service.py
@@ -208,9 +208,7 @@ class HeroService(StaticDataService):
         is sufficient.
         """
 
-        possible_gamemode_filters = self._get_hero_stats_gamemode_filters(gamemode)
-
-        for gamemode_filter in possible_gamemode_filters:
+        for gamemode_filter in await self._get_hero_stats_gamemode_filters(gamemode):
             try:
                 data = await self._get_hero_stats(
                     platform,
@@ -222,6 +220,7 @@ class HeroService(StaticDataService):
                     competitive_division,
                     order_by,
                 )
+                working_filter = gamemode_filter
                 break  # filter worked — stop retrying (data may legitimately be empty)
             except InvalidGamemodeFilterError as exc:
                 # Blizzard may have changed the filter value; try the next candidate.
@@ -233,6 +232,7 @@ class HeroService(StaticDataService):
                 blizzard_url, gamemode_filter_exception
             ) from gamemode_filter_exception
 
+        await self.cache.set_gamemode_filter(gamemode, working_filter)
         await self._update_api_cache(
             cache_key,
             data,
@@ -240,18 +240,19 @@ class HeroService(StaticDataService):
         )
         return data, False, 0
 
-    def _get_hero_stats_gamemode_filters(self, gamemode: PlayerGamemode) -> list[str]:
-        """Get gamemode filters depending on the case.
+    async def _get_hero_stats_gamemode_filters(
+        self, gamemode: PlayerGamemode
+    ) -> list[str]:
+        """Return the ordered candidate filter values to try for a given gamemode.
 
-        Gamemodes having several possible values on Blizzard side will be
-        dynamically managed with dedicated cache in a future version in order
-        to ensure continuity across calls.
+        The cached working filter (if any) is moved to the front so the correct
+        value is tried first, avoiding a redundant Blizzard call on every request.
 
         Args:
             gamemode: Gamemode for validation
 
         Returns:
-            Possible filter values for Blizzard API call
+            Filter values ordered with the cached working filter first
 
         Raises:
             ParserParsingError: If gamemode is not supported
@@ -265,7 +266,13 @@ class HeroService(StaticDataService):
             msg = f"{gamemode} is not a supported gamemode filter"
             raise ParserParsingError(msg)
 
-        return gamemode_mapping[gamemode]
+        candidates = gamemode_mapping[gamemode]
+
+        cached_filter = await self.cache.get_gamemode_filter(gamemode)
+        if cached_filter and cached_filter in candidates:
+            return [cached_filter] + [f for f in candidates if f != cached_filter]
+
+        return candidates
 
     async def _get_hero_stats(
         self,

--- a/tests/heroes/services/test_hero_service.py
+++ b/tests/heroes/services/test_hero_service.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -120,6 +120,110 @@ class TestHeroServiceGetHeroStatsGamemodeFilter:
 
         assert data == []
         assert mock_parse.call_count == 1
+
+
+class TestHeroServiceGamemodeFilterCaching:
+    _base_kwargs: ClassVar[dict] = {
+        "platform": PlayerPlatform.PC,
+        "gamemode": PlayerGamemode.COMPETITIVE,
+        "region": PlayerRegion.EUROPE,
+        "role": None,
+        "map_filter": None,
+        "competitive_division": None,
+        "order_by": "hero:asc",
+        "cache_key": "/heroes/stats",
+    }
+
+    @pytest.mark.asyncio
+    async def test_cached_filter_is_tried_first(self):
+        svc = _make_hero_service()
+        cast("Any", svc.cache).get_gamemode_filter.return_value = "2"
+        expected = [{"hero": "ana"}]
+
+        with patch(
+            "app.domain.services.hero_service.parse_hero_stats_summary",
+            return_value=expected,
+        ) as mock_parse:
+            data, _, _ = await svc.get_hero_stats(**self._base_kwargs)
+
+        assert mock_parse.call_count == 1
+        assert mock_parse.call_args.kwargs["gamemode_filter"] == "2"
+        assert data == expected
+
+    @pytest.mark.asyncio
+    async def test_no_cache_writes_working_filter(self):
+        svc = _make_hero_service()
+        cast("Any", svc.cache).get_gamemode_filter.return_value = None
+
+        with patch(
+            "app.domain.services.hero_service.parse_hero_stats_summary",
+            return_value=[],
+        ):
+            await svc.get_hero_stats(**self._base_kwargs)
+
+        cast("Any", svc.cache).set_gamemode_filter.assert_awaited_once_with(
+            PlayerGamemode.COMPETITIVE, "1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_cached_filter_falls_back_and_updates_cache(self):
+        svc = _make_hero_service()
+        cast("Any", svc.cache).get_gamemode_filter.return_value = "2"
+        expected = [{"hero": "ana"}]
+
+        with patch(
+            "app.domain.services.hero_service.parse_hero_stats_summary",
+            side_effect=[
+                InvalidGamemodeFilterError("filter '2' != selected '1'"),
+                expected,
+            ],
+        ) as mock_parse:
+            data, _, _ = await svc.get_hero_stats(**self._base_kwargs)
+
+        assert mock_parse.call_count == 2  # noqa: PLR2004
+        assert data == expected
+        cast("Any", svc.cache).set_gamemode_filter.assert_awaited_once_with(
+            PlayerGamemode.COMPETITIVE, "1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_written_to_cache_unconditionally(self):
+        svc = _make_hero_service()
+        cast("Any", svc.cache).get_gamemode_filter.return_value = "1"
+
+        with patch(
+            "app.domain.services.hero_service.parse_hero_stats_summary",
+            return_value=[],
+        ):
+            await svc.get_hero_stats(**self._base_kwargs)
+
+        cast("Any", svc.cache).set_gamemode_filter.assert_awaited_once_with(
+            PlayerGamemode.COMPETITIVE, "1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_quickplay_single_filter_cached_and_written(self):
+        svc = _make_hero_service()
+        cast("Any", svc.cache).get_gamemode_filter.return_value = None
+
+        with patch(
+            "app.domain.services.hero_service.parse_hero_stats_summary",
+            return_value=[],
+        ):
+            await svc.get_hero_stats(
+                platform=PlayerPlatform.PC,
+                gamemode=PlayerGamemode.QUICKPLAY,
+                region=PlayerRegion.EUROPE,
+                role=None,
+                map_filter=None,
+                competitive_division=None,
+                order_by="hero:asc",
+                cache_key="/heroes/stats",
+            )
+
+        cast("Any", svc.cache).set_gamemode_filter.assert_awaited_once_with(
+            PlayerGamemode.QUICKPLAY, "0"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Cache and reuse the working Blizzard gamemode filter value when fetching hero stats to reduce redundant retries and external calls.

New Features:
- Introduce persistent caching of the working Blizzard gamemode filter value per gamemode in Valkey and expose it via the cache port.

Enhancements:
- Make hero stats gamemode filter selection prefer the cached working filter and always update the cache after a successful call.

Tests:
- Add hero service tests covering gamemode filter caching, cache misses, stale cache fallback, and behavior for competitive and quickplay gamemodes.