### PR TITLE
fix: support Blizzard's new inline-SVG/hashed career-page icon format

### DIFF
--- a/app/domain/parsers/player_helpers.py
+++ b/app/domain/parsers/player_helpers.py
@@ -73,11 +73,14 @@ def get_computed_stat_value(input_str: str) -> str | float | int:
 
 def get_division_from_icon(rank_url: str) -> CompetitiveDivision:
     division_name = (
-        rank_url.rsplit("/", maxsplit=1)[-1]
+        rank_url.rsplit("/", maxsplit=1)[-1]  # filename or inline-SVG symbol id
+        .split(".", maxsplit=1)[0]  # drop content hash / ".png": "Rank_DiamondTier" / "goldtier"
         .split("-", maxsplit=1)[0]
-        .rsplit("_", maxsplit=1)[-1]
+        .rsplit("_", maxsplit=1)[-1]  # drop "Rank_" prefix: "DiamondTier" / "goldtier"
     )
-    return CompetitiveDivision(division_name[:-4].lower())
+    if division_name.lower().endswith("tier"):
+        division_name = division_name[:-4]  # strip the "Tier" suffix
+    return CompetitiveDivision(division_name.lower())
 
 
 def get_endorsement_value_from_frame(frame_url: str) -> int:
@@ -100,7 +103,10 @@ def get_hero_keyname(input_str: str) -> str:
 def get_role_key_from_icon(icon_url: str) -> CompetitiveRole:
     """Extract role key from the role icon."""
     icon_role_key = (
-        icon_url.rsplit("/", maxsplit=1)[-1].split("-", maxsplit=1)[0].upper()
+        icon_url.rsplit("/", maxsplit=1)[-1]
+        .split("-", maxsplit=1)[0]
+        .split(".", maxsplit=1)[0]  # inline-SVG symbol ids: "TANK.<hash>.SVG#ICON"
+        .upper()
     )
     return (
         CompetitiveRole.DAMAGE
@@ -122,14 +128,18 @@ def get_stats_hero_class(hero_class: str | None) -> str:
 
 
 def get_tier_from_icon(tier_url: str | None) -> int:
-    """Extracts the rank tier from the rank URL. 0 if not found."""
+    """Extracts the rank tier number from the rank URL. 0 if not found."""
     if not tier_url:
         return 0
 
-    try:
-        return int(tier_url.split("/")[-1].split("-")[0].split("_")[-1])
-    except IndexError, ValueError:
+    # Tier number is the digits right after the final "_", e.g.
+    # "TierDivision_4-<hash>.png" or "TierDivision_4.<hash>.png" -> 4.
+    # Icons without a "_" (non-tier images) yield 0.
+    filename = tier_url.rsplit("/", maxsplit=1)[-1]
+    if "_" not in filename:
         return 0
+    match = re.match(r"\d+", filename.rsplit("_", maxsplit=1)[-1])
+    return int(match.group()) if match else 0
 
 
 @cache

--- a/tests/players/test_players_helpers.py
+++ b/tests/players/test_players_helpers.py
@@ -82,6 +82,15 @@ def test_get_computed_stat_value(input_str: str, result: float | str):
             "https://static.playoverwatch.com/img/pages/career/icons/rank/Rank_UltimateTier-99f8248b65.png",
             CompetitiveDivision.ULTIMATE,
         ),
+        # New formats: content-hashed filename (dot separator) and inline-SVG symbol id
+        (
+            "https://static.playoverwatch.com/img/pages/career/icons/rank/Rank_DiamondTier.bc8c5d6005f916c62c51728087aeb26f4facaa9b.png",
+            CompetitiveDivision.DIAMOND,
+        ),
+        (
+            "goldtier.8d40eab551020b46a84002019dd98714149ed5e2",
+            CompetitiveDivision.GOLD,
+        ),
     ],
 )
 def test_get_division_from_icon(rank_url: str, division: CompetitiveDivision):
@@ -165,6 +174,15 @@ def test_get_hero_keyname(input_str: str, result: str):
             "https://static.playoverwatch.com/img/pages/career/icons/role/open-163b3b8ddc.svg#icon",
             CompetitiveRole.OPEN,
         ),
+        # New format: inline-SVG symbol id (uppercase role, dot before the hash)
+        (
+            "TANK.e363265db45af83a0a5613072d7a888b1bf8a5b5.SVG#ICON",
+            CompetitiveRole.TANK,
+        ),
+        (
+            "OFFENSE.0f3b1a2c9d4e5f6a7b8c9d0e1f2a3b4c.SVG#ICON",
+            CompetitiveRole.DAMAGE,
+        ),
     ],
 )
 def test_get_role_key_from_icon(icon_url: str, role: CompetitiveRole):
@@ -205,6 +223,11 @@ def test_get_stats_hero_class(hero_classes: str | None, result: str):
         (
             "https://static.playoverwatch.com/img/pages/career/icons/rank/6b6e7959d4.png",
             0,
+        ),
+        # New format: content-hashed filename with a dot separator before the hash
+        (
+            "https://static.playoverwatch.com/img/pages/career/icons/rank/TierDivision_4.a86ba72795dcef9e04b6346163d3369eec13393f.png",
+            4,
         ),
         (None, 0),
     ],


### PR DESCRIPTION
## What

Blizzard recently started serving competitive **role** and **rank** icons in a new format, which breaks competitive rank parsing in `_parse_summary` for any profile that has ranks.

Two new shapes are now seen in the wild:

- **Inline-SVG symbol ids:** `TANK.<hash>.SVG#ICON`, `goldtier.<hash>`
- **Content-hashed filenames:** `Rank_DiamondTier.<hash>.png`, `TierDivision_4.<hash>.png`

They appear to be rolling this out unevenly (some requests still return the old simple URLs), so the failures are intermittent.

## Errors observed

- `get_role_key_from_icon` → `KeyError('TANK.<hash>.SVG#ICON')`
- `get_division_from_icon` → `ValueError("'goldtier.<hash>' is not a valid CompetitiveDivision")`
- `get_tier_from_icon` → silently returned `0` for `TierDivision_N.<hash>.png`

## Fix

Each helper now also splits on `.` to isolate the role/division token from the trailing hash/extension, strips the `Tier` suffix for divisions, and extracts the trailing digits for the tier number. All three stay backward-compatible with the legacy URL/filename forms.

## Notes

Verified against the real failing strings (both the inline-SVG and hashed-filename variants) and the legacy forms. Happy to add regression fixtures if you point me at the preferred way to capture the new-format career HTML.

## Summary by Sourcery

Update competitive rank parsing helpers to handle Blizzard’s new inline-SVG and hashed icon formats while preserving compatibility with existing URLs.

Bug Fixes:
- Correctly extract competitive division names from both legacy rank URLs and new inline-SVG/hashed icon identifiers.
- Correctly map competitive role icons to role keys when icon identifiers include inline-SVG hashes.
- Correctly parse tier numbers from tier icon URLs that use hashed filenames or inline-SVG identifiers instead of simple filenames.