### PR TITLE
chore: improved DDD layering

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ Below is the current list of TTL values configured for the API cache. The latest
 
 ## 🐍 Architecture
 
+The codebase follows strict DDD layering — dependencies only flow inward. `domain` has no knowledge of FastAPI, Valkey, or Postgres; it only sees `typing.Protocol` ports, which `adapters` implement.
+
+```mermaid
+flowchart TD
+    api["api — routers, DI, response models"] --> domain
+    api --> adapters
+    api --> infrastructure
+    adapters["adapters — Blizzard client, Valkey cache, Postgres storage, taskiq"] --> domain
+    adapters --> infrastructure
+    domain["domain — parsers, services (SWR), ports"] -.->|logger only| infrastructure["infrastructure — logger, singletons, error helpers"]
+```
+
 ### Request flow (Stale-While-Revalidate)
 
 Every cached response is stored in Valkey as an **SWR envelope** containing the payload and three timestamps: `stored_at`, `staleness_threshold`, and `stale_while_revalidate`. Nginx/OpenResty inspects the envelope on every request:

--- a/app/domain/exceptions.py
+++ b/app/domain/exceptions.py
@@ -1,6 +1,7 @@
 """Set of custom exceptions used in the API"""
 
 from http import HTTPStatus
+from typing import Any
 
 
 class RateLimitedError(Exception):
@@ -22,10 +23,10 @@ class OverfastError(Exception):
     """Generic OverFast API Exception"""
 
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
-    message = "OverFast API Error"
+    message: str | dict[str, Any] = "OverFast API Error"
 
     def __str__(self):
-        return self.message
+        return str(self.message)
 
 
 class ParserBlizzardError(OverfastError):
@@ -34,9 +35,9 @@ class ParserBlizzardError(OverfastError):
     """
 
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
-    message = "Parser Blizzard Error"
+    message: str | dict[str, Any] = "Parser Blizzard Error"
 
-    def __init__(self, status_code: int, message: str):
+    def __init__(self, status_code: int, message: str | dict[str, Any]):
         super().__init__()
         self.status_code = status_code
         self.message = message

--- a/app/domain/parsers/hero.py
+++ b/app/domain/parsers/hero.py
@@ -1,9 +1,8 @@
 """Stateless parser functions for single hero details"""
 
 import re
+from http import HTTPStatus
 from typing import TYPE_CHECKING
-
-from fastapi import status
 
 from app.config import settings
 from app.domain.parsers.utils import (
@@ -58,7 +57,7 @@ def parse_hero_html(html: str, locale: Locale = Locale.ENGLISH_US) -> dict:
         abilities_section = root_tag.css_first("div.abilities-container")
         if not abilities_section:
             raise ParserBlizzardError(  # noqa: TRY301
-                status_code=status.HTTP_404_NOT_FOUND,
+                status_code=HTTPStatus.NOT_FOUND.value,
                 message="Hero not found or not released yet",
             )
 

--- a/app/domain/parsers/hero_stats_summary.py
+++ b/app/domain/parsers/hero_stats_summary.py
@@ -1,8 +1,7 @@
 """Stateless parser functions for hero stats summary (pickrate/winrate from Blizzard API)"""
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING
-
-from fastapi import status
 
 from app.config import settings
 from app.domain.enums import PlayerGamemode, PlayerPlatform, PlayerRegion
@@ -111,7 +110,7 @@ def parse_hero_stats_json(
     # Validate map matches gamemode (outside try so this is never caught above).
     if map_filter != selected_map:
         raise ParserBlizzardError(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=HTTPStatus.BAD_REQUEST.value,
             message=f"Selected map '{map_filter}' is not compatible with '{gamemode}' gamemode.",
         )
 

--- a/app/domain/parsers/player_helpers.py
+++ b/app/domain/parsers/player_helpers.py
@@ -74,7 +74,9 @@ def get_computed_stat_value(input_str: str) -> str | float | int:
 def get_division_from_icon(rank_url: str) -> CompetitiveDivision:
     division_name = (
         rank_url.rsplit("/", maxsplit=1)[-1]  # filename or inline-SVG symbol id
-        .split(".", maxsplit=1)[0]  # drop content hash / ".png": "Rank_DiamondTier" / "goldtier"
+        .split(".", maxsplit=1)[
+            0
+        ]  # drop content hash / ".png": "Rank_DiamondTier" / "goldtier"
         .split("-", maxsplit=1)[0]
         .rsplit("_", maxsplit=1)[-1]  # drop "Rank_" prefix: "DiamondTier" / "goldtier"
     )

--- a/app/domain/parsers/player_profile.py
+++ b/app/domain/parsers/player_profile.py
@@ -7,9 +7,8 @@ This module handles parsing of player profile HTML including:
 - Career stats (detailed statistics per hero)
 """
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING
-
-from fastapi import status
 
 from app.config import settings
 from app.domain.exceptions import ParserBlizzardError, ParserParsingError
@@ -138,7 +137,7 @@ def parse_player_profile_html(
     # Check if player exists
     if not root_tag.css_first("blz-section.Profile-masthead"):
         raise ParserBlizzardError(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=HTTPStatus.NOT_FOUND.value,
             message="Player not found",
         )
 

--- a/app/domain/services/hero_service.py
+++ b/app/domain/services/hero_service.py
@@ -3,13 +3,10 @@
 import json
 from typing import TYPE_CHECKING, Any
 
-from fastapi import HTTPException
-
 from app.config import settings
 from app.domain.enums import Locale, PlayerGamemode, SubRole
 from app.domain.exceptions import (
     InvalidGamemodeFilterError,
-    ParserBlizzardError,
     ParserInternalError,
     ParserParsingError,
 )
@@ -115,18 +112,12 @@ class HeroService(StaticDataService):
         """Build a StaticFetchConfig for a single hero detail."""
 
         async def _fetch() -> str:
-            try:
-                hero_html = await fetch_hero_html(
-                    self.blizzard_client, hero_key, locale
-                )
-                # Validate hero exists before making the second Blizzard request.
-                # parse_hero_html raises ParserBlizzardError (404) for unknown heroes.
-                parse_hero_html(hero_html, locale)
-                heroes_html = await fetch_heroes_html(self.blizzard_client, locale)
-            except ParserBlizzardError as exc:
-                raise HTTPException(
-                    status_code=exc.status_code, detail=exc.message
-                ) from exc
+            hero_html = await fetch_hero_html(self.blizzard_client, hero_key, locale)
+            # Validate hero exists before making the second Blizzard request.
+            # parse_hero_html raises ParserBlizzardError (404) for unknown heroes,
+            # which propagates to the API layer's registered OverfastError handler.
+            parse_hero_html(hero_html, locale)
+            heroes_html = await fetch_heroes_html(self.blizzard_client, locale)
             return json.dumps(
                 {"hero_html": hero_html, "heroes_html": heroes_html},
                 separators=(",", ":"),
@@ -297,10 +288,6 @@ class HeroService(StaticDataService):
                 competitive_division=competitive_division,
                 order_by=order_by,
             )
-        except ParserBlizzardError as exc:
-            raise HTTPException(
-                status_code=exc.status_code, detail=exc.message
-            ) from exc
         except ParserParsingError as exc:
             blizzard_url = f"{settings.blizzard_host}{settings.hero_stats_path}"
             raise ParserInternalError(blizzard_url, exc) from exc

--- a/app/domain/services/player_service.py
+++ b/app/domain/services/player_service.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Never, cast
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-from fastapi import HTTPException
-
 from app.config import settings
 from app.domain.enums import HeroKeyCareerFilter, PlayerGamemode, PlayerPlatform
 from app.domain.exceptions import (
@@ -590,7 +588,7 @@ class PlayerService(BaseService):
     async def _mark_player_unknown(
         self,
         blizzard_id: str,
-        exception: HTTPException,
+        exception: ParserBlizzardError,
         battletag: str | None = None,
     ) -> None:
         if not settings.unknown_players_cache_enabled:
@@ -607,7 +605,7 @@ class PlayerService(BaseService):
             blizzard_id, check_count, retry_after, battletag=battletag
         )
 
-        exception.detail = {  # ty: ignore[invalid-assignment]
+        exception.message = {
             "error": "Player not found",
             "retry_after": retry_after,
             "next_check_at": next_check_at,
@@ -627,41 +625,37 @@ class PlayerService(BaseService):
         player_id: str,
         identity: PlayerIdentity,
     ) -> Never:
-        """Translate all player exceptions to HTTPException and always raise."""
+        """Translate known parser exceptions to a client-facing error and always raise.
+
+        Raised errors are ``ParserBlizzardError``/``ParserInternalError`` — the API
+        layer's registered ``OverfastError`` handler turns them into HTTP responses.
+        """
         effective_id = identity.blizzard_id or player_id
         battletag_input = identity.battletag_input
         player_summary = identity.player_summary
 
         if isinstance(error, ParserBlizzardError):
-            exc = HTTPException(status_code=error.status_code, detail=error.message)
             if error.status_code == HTTPStatus.NOT_FOUND.value:
                 await self._mark_player_unknown(
-                    effective_id, exc, battletag=battletag_input
+                    effective_id, error, battletag=battletag_input
                 )
-            raise exc from error
+            raise error
 
         if isinstance(error, ParserParsingError):
             if "Could not find main content in HTML" in str(error):
-                exc = HTTPException(
+                not_found = ParserBlizzardError(
                     status_code=HTTPStatus.NOT_FOUND.value,
-                    detail="Player not found",
+                    message="Player not found",
                 )
                 await self._mark_player_unknown(
-                    effective_id, exc, battletag=battletag_input
+                    effective_id, not_found, battletag=battletag_input
                 )
-                raise exc from error
+                raise not_found from error
 
             blizzard_url = (
                 f"{settings.blizzard_host}{settings.career_path}/"
                 f"{player_summary.get('url', effective_id) if player_summary else effective_id}/"
             )
             raise ParserInternalError(blizzard_url, error) from error
-
-        if isinstance(error, HTTPException):
-            if error.status_code == HTTPStatus.NOT_FOUND.value:
-                await self._mark_player_unknown(
-                    effective_id, error, battletag=battletag_input
-                )
-            raise error
 
         raise error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,11 +143,19 @@ ignore = [
 allowed-confusables = ["（", "）", "："]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["SLF001"]  # Ignore private member access in tests
+"tests/**" = ["SLF001", "TID251"]  # Ignore private member access + fastapi.TestClient in tests
 "app/api/models/**" = ["TC001"]  # Ignore type-checking block (Pydantic models definition)
 "app/api/routers/**" = ["TC001"]  # Enums used in FastAPI path/query parameters need runtime import
 "app/api/dependencies.py" = ["TC001"]  # Port types needed at runtime for FastAPI Depends
 "app/domain/services/**" = ["TC001"]  # Locale/enums used in runtime method annotations
+"app/api/**" = ["TID251"]           # API layer owns FastAPI
+"app/adapters/**" = ["TID251"]      # BlizzardClient raises HTTPException for transport errors
+"app/infrastructure/**" = ["TID251"]  # Shared HTTPException helpers (Discord alerts, etc.)
+"app/monitoring/**" = ["TID251"]    # Prometheus/FastAPI router glue
+"app/main.py" = ["TID251"]          # App assembly
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"fastapi".msg = "Domain layer must stay framework-agnostic. Raise app.domain.exceptions instead of fastapi.HTTPException, use http.HTTPStatus instead of fastapi.status."
 
 [tool.ruff.lint.isort]
 # Consider app as first-party for imports in tests

--- a/tests/heroes/parsers/test_hero_stats_summary.py
+++ b/tests/heroes/parsers/test_hero_stats_summary.py
@@ -111,8 +111,10 @@ async def test_parse_hero_stats_summary_invalid_map_error_message(
                 map_filter="hanaoka",
             )
 
-    assert "hanaoka" in exc_info.value.message
-    assert "compatible" in exc_info.value.message.lower()
+    message = str(exc_info.value.message)
+
+    assert "hanaoka" in message
+    assert "compatible" in message.lower()
 
 
 def test_parse_hero_stats_json_raises_invalid_gamemode_filter_error():

--- a/tests/players/services/test_player_service.py
+++ b/tests/players/services/test_player_service.py
@@ -269,7 +269,9 @@ class TestMarkPlayerUnknown:
     @pytest.mark.asyncio
     async def test_disabled_feature_is_noop(self):
         svc = _make_service()
-        exc = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+        exc = ParserBlizzardError(
+            status_code=status.HTTP_404_NOT_FOUND, message="not found"
+        )
         with patch("app.domain.services.player_service.settings") as s:
             s.unknown_players_cache_enabled = False
             await svc._mark_player_unknown("abc123", exc)
@@ -278,8 +280,8 @@ class TestMarkPlayerUnknown:
     @pytest.mark.asyncio
     async def test_non_404_is_noop(self):
         svc = _make_service()
-        exc = HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="error"
+        exc = ParserBlizzardError(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, message="error"
         )
         with patch("app.domain.services.player_service.settings") as s:
             s.unknown_players_cache_enabled = True
@@ -292,7 +294,9 @@ class TestMarkPlayerUnknown:
         cache.get_player_status = AsyncMock(return_value=None)
         cache.set_player_status = AsyncMock()
         svc = _make_service(cache=cache)
-        exc = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+        exc = ParserBlizzardError(
+            status_code=status.HTTP_404_NOT_FOUND, message="not found"
+        )
         with patch("app.domain.services.player_service.settings") as s:
             s.unknown_players_cache_enabled = True
             s.unknown_player_initial_retry = 60
@@ -307,7 +311,9 @@ class TestMarkPlayerUnknown:
         cache.get_player_status = AsyncMock(return_value={"check_count": 3})
         cache.set_player_status = AsyncMock()
         svc = _make_service(cache=cache)
-        exc = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+        exc = ParserBlizzardError(
+            status_code=status.HTTP_404_NOT_FOUND, message="not found"
+        )
         with patch("app.domain.services.player_service.settings") as s:
             s.unknown_players_cache_enabled = True
             s.unknown_player_initial_retry = 60
@@ -336,7 +342,7 @@ class TestHandlePlayerExceptions:
         identity = PlayerIdentity()
         with patch("app.domain.services.player_service.settings") as s:
             s.unknown_players_cache_enabled = False
-            with pytest.raises(HTTPException) as exc_info:
+            with pytest.raises(ParserBlizzardError) as exc_info:
                 await svc._handle_player_exceptions(error, "TeKrop-2217", identity)
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
@@ -348,7 +354,7 @@ class TestHandlePlayerExceptions:
         identity = PlayerIdentity()
         with patch("app.domain.services.player_service.settings") as s:
             s.unknown_players_cache_enabled = False
-            with pytest.raises(HTTPException) as exc_info:
+            with pytest.raises(ParserBlizzardError) as exc_info:
                 await svc._handle_player_exceptions(error, "TeKrop-2217", identity)
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
@@ -369,14 +375,18 @@ class TestHandlePlayerExceptions:
         assert exc_info.value.cause is error
 
     @pytest.mark.asyncio
-    async def test_http_exception_404_marks_and_reraises(self):
+    async def test_unrecognized_exception_type_reraises_unmarked(self):
+        """An HTTPException raised by the Blizzard adapter (e.g. 503 rate limit)
+        isn't a domain exception, so it passes through unchanged — no unknown-player
+        marking, since the marking logic only inspects ParserBlizzardError/ParserParsingError."""
         svc = _make_service()
         error = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
         identity = PlayerIdentity()
-        with patch("app.domain.services.player_service.settings") as s:
-            s.unknown_players_cache_enabled = False
-            with pytest.raises(HTTPException):
-                await svc._handle_player_exceptions(error, "TeKrop-2217", identity)
+        with pytest.raises(HTTPException) as exc_info:
+            await svc._handle_player_exceptions(error, "TeKrop-2217", identity)
+
+        assert exc_info.value is error
+        cast("Any", svc.cache).set_player_status.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_http_exception_non_404_reraises(self):
@@ -699,10 +709,10 @@ class TestRefreshPlayerProfile:
         assert profile is not None
 
     @pytest.mark.asyncio
-    async def test_blizzard_error_propagates_as_http_exception(self):
-        """A ParserBlizzardError from identity resolution is translated to an
-        HTTPException by _handle_player_exceptions and re-raised — the worker's
-        _run_refresh_task except block captures it."""
+    async def test_blizzard_error_propagates(self):
+        """A ParserBlizzardError from identity resolution is re-raised as-is by
+        _handle_player_exceptions — the worker's _run_refresh_task except block
+        captures it."""
         svc = _make_service()
         err = ParserBlizzardError(
             status.HTTP_503_SERVICE_UNAVAILABLE, "Blizzard unavailable"
@@ -722,7 +732,7 @@ class TestRefreshPlayerProfile:
             s.player_staleness_threshold = 3600
             s.prometheus_enabled = False
             s.unknown_players_cache_enabled = False
-            with pytest.raises(HTTPException) as exc_info:
+            with pytest.raises(ParserBlizzardError) as exc_info:
                 await svc.refresh_player_profile("TeKrop-2217")
 
         assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/tests/players/services/test_player_service.py
+++ b/tests/players/services/test_player_service.py
@@ -303,7 +303,13 @@ class TestMarkPlayerUnknown:
             s.unknown_player_retry_multiplier = 2
             s.unknown_player_max_retry = 3600
             await svc._mark_player_unknown("abc123", exc, battletag="TeKrop-2217")
+
         cache.set_player_status.assert_awaited_once()
+        assert isinstance(exc.message, dict)
+        assert exc.message["error"] == "Player not found"
+        assert "retry_after" in exc.message
+        assert "next_check_at" in exc.message
+        assert "check_count" in exc.message
 
     @pytest.mark.asyncio
     async def test_404_increments_check_count(self):

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "4.7.0"
+version = "4.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary by Sourcery

Enforce framework-agnostic domain layering by having domain services and parsers raise and propagate domain-specific exceptions instead of FastAPI HTTPException, and update tests, linting, and documentation to reflect the new error-handling and layering rules.

Bug Fixes:
- Ensure unknown-player marking logic only applies to recognized parser errors and does not run for arbitrary HTTPException instances raised by adapters.

Enhancements:
- Refine player service exception handling to propagate ParserBlizzardError/ParserInternalError directly and centralize HTTP response translation in the API layer.
- Allow OverfastError/ParserBlizzardError message payloads to be structured data for richer client-facing error details.
- Simplify hero service by letting parser-level ParserBlizzardError propagate instead of being wrapped into HTTPException.
- Update parsers to depend on standard http.HTTPStatus instead of FastAPI status codes, improving domain independence.

Build:
- Tighten Ruff configuration to ban direct FastAPI usage in the domain layer and to scope TID251 ignores to API- and adapter-facing packages.

Documentation:
- Document the DDD layering and dependency flow in the README, including a mermaid diagram of the architecture.

Tests:
- Adjust player and hero parser/service tests to assert on ParserBlizzardError propagation, updated message typing, and the refined unknown-player marking behavior.