### PR TITLE
fix: fixed uv lock not being properly updated after release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,10 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      GIT_COMMITTER_NAME: "github-actions"
+      GIT_COMMITTER_EMAIL: "actions@users.noreply.github.com"
+
     steps:
       - name: Setup | Checkout Repository
         uses: actions/checkout@v7
@@ -28,8 +32,8 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_committer_name: "github-actions"
-          git_committer_email: "actions@users.noreply.github.com"
+          git_committer_name: ${{ env.GIT_COMMITTER_NAME }}
+          git_committer_email: ${{ env.GIT_COMMITTER_EMAIL }}
 
       - name: Setup | uv
         if: steps.release.outputs.released == 'true'
@@ -42,10 +46,13 @@ jobs:
         run: |
           uv lock
           if ! git diff --quiet -- uv.lock; then
-            git config user.name "github-actions"
-            git config user.email "actions@users.noreply.github.com"
+            # The PSR step's git config above only applies inside its own Docker
+            # container, so it isn't visible to this (non-containerized) step.
+            git config user.name "$GIT_COMMITTER_NAME"
+            git config user.email "$GIT_COMMITTER_EMAIL"
             git add uv.lock
             git commit -m "chore: update uv.lock for v${{ steps.release.outputs.version }}"
+            git pull --rebase
             git push
           fi
   deploy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
+
+      - name: Setup | uv
+        if: steps.release.outputs.released == 'true'
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "0.11.26"
+
+      - name: Update | uv.lock
+        if: steps.release.outputs.released == 'true'
+        run: |
+          uv lock
+          if ! git diff --quiet -- uv.lock; then
+            git config user.name "github-actions"
+            git config user.email "actions@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: update uv.lock for v${{ steps.release.outputs.version }}"
+            git push
+          fi
   deploy:
     name: Deploy on VPS
     needs: release

--- a/uv.lock
+++ b/uv.lock
@@ -826,7 +826,7 @@ wheels = [
 
 [[package]]
 name = "overfast-api"
-version = "4.8.1"
+version = "4.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary by Sourcery

Ensure the release workflow updates and commits uv.lock after a successful release.

Build:
- Extend the release GitHub Actions workflow to install uv and regenerate uv.lock when a new version is released.

Chores:
- Refresh uv.lock to reflect the current dependency state after release.