### PR TITLE
docs: promote OverGraphQL API in README and Redoc description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 > OverFast API provides comprehensive data on Overwatch heroes, game modes, maps, and player statistics by scraping Blizzard pages. Built with **FastAPI** and **Selectolax**, **PostgreSQL** for persistent storage, **Stale-While-Revalidate caching** via **Valkey** and **nginx (OpenResty)**, **taskiq** background workers, and **TCP Slow Start + AIMD throttling** for Blizzard requests.
 
+> 🕸️ Prefer GraphQL ? Check out [**OverGraphQL API**](https://github.com/TeKrop/overgraphql-api), a GraphQL facade over OverFast API exposing the same data as a single relational graph — fetch exactly what you need in one query.
+
 ## Table of contents
 * [✨ Live instance](#-live-instance)
 * [🐋 Run for production](#-run-for-production)

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,10 @@ This live instance is configured with the following restrictions:
 This limit may be adjusted as needed. If you require higher throughput, consider
 hosting your own instance on a server 👍
 
+🕸️ Prefer GraphQL ? Check out
+[OverGraphQL API](https://github.com/TeKrop/overgraphql-api), a GraphQL facade
+over OverFast API exposing the same data as a single relational graph.
+
 Swagger UI (useful for trying API calls) : {settings.app_base_url}/docs
 
 {f"Status page : {settings.status_page_url}" if settings.status_page_url else ""}


### PR DESCRIPTION
## What

Promotes [OverGraphQL API](https://github.com/TeKrop/overgraphql-api) on the two entry points of OverFast API:

- **README**: a blockquote callout right under the intro, before the table of contents
- **Redoc page**: a paragraph in the app description (`app/main.py`), rendered at the top of the documentation, just above the Swagger UI link

Both link to the GitHub repo for now — easy to swap for a live instance URL once one exists.

## Checks

- `just check`, `just lint` clean
- `just test`: 775 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Promote the OverGraphQL API as a recommended GraphQL facade for OverFast across main documentation entry points.

Documentation:
- Highlight OverGraphQL API in the README as a GraphQL facade over OverFast for fetching data via a single relational graph.
- Add a brief OverGraphQL API mention in the Redoc/app description so it appears at the top of the generated API documentation.