### PR TITLE
chore: add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.venv
+.pytest_cache
+.ruff_cache
+.opencode
+.claude
+htmlcov
+logs
+__pycache__
+*.pyc
+.env
+.env.dist
+*.md
+LICENSE
+docker-compose.yml


### PR DESCRIPTION
## Summary
- Add a `.dockerignore` excluding `.git`, `.venv`, caches, logs, and other files that don't belong in the Docker build context.

Without it the build context was 442MB (`.venv` alone is 291MB, `.git` 57MB), all sent to the Docker daemon on every build for nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a .dockerignore file to reduce the Docker build context size by excluding unnecessary local files and directories.

Build:
- Introduce a .dockerignore configuration that omits VCS metadata, virtual environments, caches, logs, and other non-essential files from the Docker build context.

Chores:
- Add repository housekeeping to prevent large local artifacts from being sent to the Docker daemon during image builds.