### PR TITLE
fix: exclude the uv.lock bump commit from the generated changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,5 +169,8 @@ version_toml = ["pyproject.toml:project.version"]
 [tool.semantic_release.commit_parser_options]
 parse_squash_commits = false
 
+[tool.semantic_release.changelog]
+exclude_commit_patterns = ['^chore: update uv\.lock for v\d+\.\d+\.\d+$']
+
 [tool.semantic_release.publish]
 upload_to_vcs_release = false


### PR DESCRIPTION
## Summary
- `release.yaml` pushes a `chore: update uv.lock for v{version}` commit after every release, which then always gets swept into the *next* release's changelog under an already-stale version number.
- Excludes it from the generated `CHANGELOG.md` via `exclude_commit_patterns`. This only affects changelog rendering, not conventional-commit bump logic, so it has no effect on versioning.
- Same fix as [TeKrop/overgraphql-api#21](https://github.com/TeKrop/overgraphql-api/pull/21).

## Test plan
- [x] `pyproject.toml` parses correctly
- [x] `just lint` / `just check` pass (via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)