### PR TITLE
feat: added emerald competitive division

### DIFF
--- a/app/domain/enums.py
+++ b/app/domain/enums.py
@@ -191,6 +191,7 @@ class CompetitiveDivision(StrEnum):
     SILVER = "silver"
     GOLD = "gold"
     PLATINUM = "platinum"
+    EMERALD = "emerald"
     DIAMOND = "diamond"
     MASTER = "master"
     GRANDMASTER = "grandmaster"

--- a/tests/players/test_players_helpers.py
+++ b/tests/players/test_players_helpers.py
@@ -71,6 +71,10 @@ def test_get_computed_stat_value(input_str: str, result: float | str):
             CompetitiveDivision.DIAMOND,
         ),
         (
+            "https://static.playoverwatch.com/img/pages/career/icons/rank/EmeraldTier-2-397f8722e0.png",
+            CompetitiveDivision.EMERALD,
+        ),
+        (
             "https://static.playoverwatch.com/img/pages/career/icons/rank/MasterTier-4-397f8722e0.png",
             CompetitiveDivision.MASTER,
         ),


### PR DESCRIPTION
Closes #450

Adds the new `emerald` rank tier, between platinum and diamond.

Single enum entry in `CompetitiveDivision` — `CompetitiveDivisionFilter`, the rank icon parser (`EmeraldTier` → `emerald`) and the `/heroes/stats` division filter (`Emerald`) all derive from it. One parser test case added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add the emerald competitive division tier between platinum and diamond and update related parsing and tests.

New Features:
- Introduce an EMERALD tier to the CompetitiveDivision enum to represent the new competitive rank.

Tests:
- Extend player helper rank parsing tests to cover the new EmeraldTier icon mapping to the EMERALD division.