### PR TITLE
feat: added banrate in heroes stats

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/app/api/models/heroes.py
+++ b/app/api/models/heroes.py
@@ -336,6 +336,12 @@ class HeroStatsSummary(BaseModel):
     )
     pickrate: float = Field(..., description="Pickrate (in percent)", ge=0.0, le=100.0)
     winrate: float = Field(..., description="Winrate (in percent)", ge=0.0, le=100.0)
+    banrate: float | None = Field(
+        None,
+        description="Banrate (in percent). Only available for the competitive gamemode.",
+        ge=0.0,
+        le=100.0,
+    )
 
 
 class BadRequestErrorMessage(BaseModel):

--- a/app/api/routers/heroes.py
+++ b/app/api/routers/heroes.py
@@ -89,6 +89,7 @@ async def list_heroes(
     ),
     operation_id="get_hero_stats",
     response_model=list[HeroStatsSummary],
+    response_model_exclude_none=True,
 )
 async def get_hero_stats(
     request: Request,
@@ -130,7 +131,7 @@ async def get_hero_stats(
         str,
         Query(
             title="Ordering field and the way it's arranged (asc[ending]/desc[ending])",
-            pattern=r"^(hero|winrate|pickrate):(asc|desc)$",
+            pattern=r"^(hero|winrate|pickrate|banrate):(asc|desc)$",
         ),
     ] = "hero:asc",
 ) -> Any:

--- a/app/domain/parsers/hero_stats_summary.py
+++ b/app/domain/parsers/hero_stats_summary.py
@@ -1,4 +1,4 @@
-"""Stateless parser functions for hero stats summary (pickrate/winrate from Blizzard API)"""
+"""Stateless parser functions for hero stats summary (pickrate/winrate/banrate from Blizzard API)"""
 
 from http import HTTPStatus
 from typing import TYPE_CHECKING
@@ -80,7 +80,8 @@ def parse_hero_stats_json(
         order_by: Ordering field and direction (e.g., "pickrate:desc")
 
     Returns:
-        List of hero stats dicts with hero, pickrate, winrate
+        List of hero stats dicts with hero, pickrate, winrate, banrate
+        (banrate is None outside of the competitive gamemode)
 
     Raises:
         ParserBlizzardError: If map doesn't match gamemode
@@ -127,6 +128,13 @@ def parse_hero_stats_json(
                 "hero": rate["id"],
                 "pickrate": _normalize_rate(rate["cells"]["pickrate"]),
                 "winrate": _normalize_rate(rate["cells"]["winrate"]),
+                # Blizzard doesn't track bans outside competitive; a rate would be 0.0
+                # for every hero there, which is not accurate data to expose.
+                "banrate": (
+                    _normalize_rate(rate["cells"]["banrate"])
+                    if gamemode == PlayerGamemode.COMPETITIVE
+                    else None
+                ),
             }
             for rate in hero_stats
         ]
@@ -136,6 +144,12 @@ def parse_hero_stats_json(
 
     # Apply ordering
     order_field, order_arrangement = order_by.split(":")
+    if order_field == "banrate" and gamemode != PlayerGamemode.COMPETITIVE:
+        msg = "Cannot order by 'banrate' outside of the competitive gamemode."
+        raise ParserBlizzardError(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            message=msg,
+        )
     hero_stats.sort(
         key=lambda stat: stat[order_field],
         reverse=(order_arrangement == "desc"),

--- a/tests/fixtures/json/blizzard_hero_stats.json
+++ b/tests/fixtures/json/blizzard_hero_stats.json
@@ -14,7 +14,8 @@
                 "cells": {
                     "name": "Ana",
                     "pickrate": 22.3,
-                    "winrate": 43.1
+                    "winrate": 43.1,
+                    "banrate": 1.6
                 },
                 "hero": {
                     "color": "48699eff",
@@ -29,7 +30,8 @@
                 "cells": {
                     "name": "Ashe",
                     "pickrate": 28.9,
-                    "winrate": 55.1
+                    "winrate": 55.1,
+                    "banrate": 3.8
                 },
                 "hero": {
                     "color": "3e3c3aff",
@@ -44,7 +46,8 @@
                 "cells": {
                     "name": "Baptiste",
                     "pickrate": 47.8,
-                    "winrate": 57.4
+                    "winrate": 57.4,
+                    "banrate": 3.3
                 },
                 "hero": {
                     "color": "28a5c3ff",
@@ -59,7 +62,8 @@
                 "cells": {
                     "name": "Bastion",
                     "pickrate": 2.7,
-                    "winrate": 57
+                    "winrate": 57,
+                    "banrate": 1.7
                 },
                 "hero": {
                     "color": "5b7351ff",
@@ -74,7 +78,8 @@
                 "cells": {
                     "name": "Brigitte",
                     "pickrate": 25.2,
-                    "winrate": 46.8
+                    "winrate": 46.8,
+                    "banrate": 1.4
                 },
                 "hero": {
                     "color": "72332aff",
@@ -89,7 +94,8 @@
                 "cells": {
                     "name": "Cassidy",
                     "pickrate": 21.3,
-                    "winrate": 41
+                    "winrate": 41,
+                    "banrate": 2.8
                 },
                 "hero": {
                     "color": "a62927ff",
@@ -104,7 +110,8 @@
                 "cells": {
                     "name": "D.Va",
                     "pickrate": 12.9,
-                    "winrate": 64.8
+                    "winrate": 64.8,
+                    "banrate": 3.3
                 },
                 "hero": {
                     "color": "fc79bdff",
@@ -119,7 +126,8 @@
                 "cells": {
                     "name": "Doomfist",
                     "pickrate": 7.2,
-                    "winrate": 43.5
+                    "winrate": 43.5,
+                    "banrate": 1.4
                 },
                 "hero": {
                     "color": "661e0fff",
@@ -134,7 +142,8 @@
                 "cells": {
                     "name": "Echo",
                     "pickrate": 1,
-                    "winrate": 59.1
+                    "winrate": 59.1,
+                    "banrate": 4.9
                 },
                 "hero": {
                     "color": "89c8ffff",
@@ -149,7 +158,8 @@
                 "cells": {
                     "name": "Freja",
                     "pickrate": 2.7,
-                    "winrate": 46
+                    "winrate": 46,
+                    "banrate": 1.7
                 },
                 "hero": {
                     "color": "3f93ffff",
@@ -164,7 +174,8 @@
                 "cells": {
                     "name": "Genji",
                     "pickrate": 10.4,
-                    "winrate": 49.8
+                    "winrate": 49.8,
+                    "banrate": 0.3
                 },
                 "hero": {
                     "color": "80fb00ff",
@@ -179,7 +190,8 @@
                 "cells": {
                     "name": "Hanzo",
                     "pickrate": 4.5,
-                    "winrate": 50.2
+                    "winrate": 50.2,
+                    "banrate": 1.7
                 },
                 "hero": {
                     "color": "b2a865ff",
@@ -194,7 +206,8 @@
                 "cells": {
                     "name": "Hazard",
                     "pickrate": 7.9,
-                    "winrate": 50.7
+                    "winrate": 50.7,
+                    "banrate": 4.7
                 },
                 "hero": {
                     "color": "985ec0ff",
@@ -209,7 +222,8 @@
                 "cells": {
                     "name": "Illari",
                     "pickrate": 32.2,
-                    "winrate": 57.2
+                    "winrate": 57.2,
+                    "banrate": 3.2
                 },
                 "hero": {
                     "color": "a58c54ff",
@@ -224,7 +238,8 @@
                 "cells": {
                     "name": "Junker Queen",
                     "pickrate": 4.3,
-                    "winrate": 45.9
+                    "winrate": 45.9,
+                    "banrate": 4.6
                 },
                 "hero": {
                     "color": "579fcfff",
@@ -239,7 +254,8 @@
                 "cells": {
                     "name": "Junkrat",
                     "pickrate": 1.1,
-                    "winrate": 33.9
+                    "winrate": 33.9,
+                    "banrate": 5.0
                 },
                 "hero": {
                     "color": "f7b217ff",
@@ -254,7 +270,8 @@
                 "cells": {
                     "name": "Juno",
                     "pickrate": 3.1,
-                    "winrate": 56.4
+                    "winrate": 56.4,
+                    "banrate": 4.4
                 },
                 "hero": {
                     "color": "721fa3ff",
@@ -269,7 +286,8 @@
                 "cells": {
                     "name": "Kiriko",
                     "pickrate": 19.7,
-                    "winrate": 41.2
+                    "winrate": 41.2,
+                    "banrate": 2.9
                 },
                 "hero": {
                     "color": "d04656ff",
@@ -284,7 +302,8 @@
                 "cells": {
                     "name": "Lifeweaver",
                     "pickrate": 3.8,
-                    "winrate": 31
+                    "winrate": 31,
+                    "banrate": 1.1
                 },
                 "hero": {
                     "color": "e1a5baff",
@@ -299,7 +318,8 @@
                 "cells": {
                     "name": "L\u00facio",
                     "pickrate": 8.4,
-                    "winrate": 52.7
+                    "winrate": 52.7,
+                    "banrate": 4.8
                 },
                 "hero": {
                     "color": "67c519ff",
@@ -314,7 +334,8 @@
                 "cells": {
                     "name": "Mauga",
                     "pickrate": 15.2,
-                    "winrate": 52.5
+                    "winrate": 52.5,
+                    "banrate": 2.5
                 },
                 "hero": {
                     "color": "db4216ff",
@@ -329,7 +350,8 @@
                 "cells": {
                     "name": "Mei",
                     "pickrate": 4.4,
-                    "winrate": 43.9
+                    "winrate": 43.9,
+                    "banrate": 1.3
                 },
                 "hero": {
                     "color": "469af0ff",
@@ -344,7 +366,8 @@
                 "cells": {
                     "name": "Mercy",
                     "pickrate": 10.4,
-                    "winrate": 48.5
+                    "winrate": 48.5,
+                    "banrate": 2.6
                 },
                 "hero": {
                     "color": "faf2adff",
@@ -359,7 +382,8 @@
                 "cells": {
                     "name": "Moira",
                     "pickrate": 6,
-                    "winrate": 35
+                    "winrate": 35,
+                    "banrate": 1.1
                 },
                 "hero": {
                     "color": "804be5ff",
@@ -374,7 +398,8 @@
                 "cells": {
                     "name": "Orisa",
                     "pickrate": -1,
-                    "winrate": -1
+                    "winrate": -1,
+                    "banrate": 3.1
                 },
                 "hero": {
                     "color": "106f04ff",
@@ -389,7 +414,8 @@
                 "cells": {
                     "name": "Pharah",
                     "pickrate": 2.4,
-                    "winrate": 62.8
+                    "winrate": 62.8,
+                    "banrate": 4.9
                 },
                 "hero": {
                     "color": "58bcff",
@@ -404,7 +430,8 @@
                 "cells": {
                     "name": "Ramattra",
                     "pickrate": 4.2,
-                    "winrate": 37.7
+                    "winrate": 37.7,
+                    "banrate": 2.2
                 },
                 "hero": {
                     "color": "7d55c7ff",
@@ -419,7 +446,8 @@
                 "cells": {
                     "name": "Reaper",
                     "pickrate": 4.2,
-                    "winrate": 49.5
+                    "winrate": 49.5,
+                    "banrate": 4.0
                 },
                 "hero": {
                     "color": "5e001aff",
@@ -434,7 +462,8 @@
                 "cells": {
                     "name": "Reinhardt",
                     "pickrate": 5.3,
-                    "winrate": 48.8
+                    "winrate": 48.8,
+                    "banrate": 3.4
                 },
                 "hero": {
                     "color": "7c8b8cff",
@@ -449,7 +478,8 @@
                 "cells": {
                     "name": "Roadhog",
                     "pickrate": 3.5,
-                    "winrate": 42.6
+                    "winrate": 42.6,
+                    "banrate": 3.2
                 },
                 "hero": {
                     "color": "ae6f1cff",
@@ -464,7 +494,8 @@
                 "cells": {
                     "name": "Sigma",
                     "pickrate": 9.2,
-                    "winrate": 54.6
+                    "winrate": 54.6,
+                    "banrate": 1.2
                 },
                 "hero": {
                     "color": "7c8b8cff",
@@ -479,7 +510,8 @@
                 "cells": {
                     "name": "Sojourn",
                     "pickrate": 33.3,
-                    "winrate": 45.2
+                    "winrate": 45.2,
+                    "banrate": 3.9
                 },
                 "hero": {
                     "color": "d73e2cff",
@@ -494,7 +526,8 @@
                 "cells": {
                     "name": "Soldier: 76",
                     "pickrate": 36.6,
-                    "winrate": 50
+                    "winrate": 50,
+                    "banrate": 3.6
                 },
                 "hero": {
                     "color": "445275ff",
@@ -509,7 +542,8 @@
                 "cells": {
                     "name": "Sombra",
                     "pickrate": 5,
-                    "winrate": 50
+                    "winrate": 50,
+                    "banrate": 1.6
                 },
                 "hero": {
                     "color": "5128a9ff",
@@ -524,7 +558,8 @@
                 "cells": {
                     "name": "Symmetra",
                     "pickrate": 4.2,
-                    "winrate": 61.1
+                    "winrate": 61.1,
+                    "banrate": 1.4
                 },
                 "hero": {
                     "color": "76b4c9ff",
@@ -539,7 +574,8 @@
                 "cells": {
                     "name": "Torbj\u00f6rn",
                     "pickrate": 1.8,
-                    "winrate": 38.3
+                    "winrate": 38.3,
+                    "banrate": 3.1
                 },
                 "hero": {
                     "color": "ba4c3fff",
@@ -554,7 +590,8 @@
                 "cells": {
                     "name": "Tracer",
                     "pickrate": 22.1,
-                    "winrate": 54.1
+                    "winrate": 54.1,
+                    "banrate": 4.9
                 },
                 "hero": {
                     "color": "de7a00ff",
@@ -569,7 +606,8 @@
                 "cells": {
                     "name": "Venture",
                     "pickrate": 4.5,
-                    "winrate": 45.8
+                    "winrate": 45.8,
+                    "banrate": 3.0
                 },
                 "hero": {
                     "color": "79614eff",
@@ -584,7 +622,8 @@
                 "cells": {
                     "name": "Widowmaker",
                     "pickrate": 10.6,
-                    "winrate": 56
+                    "winrate": 56,
+                    "banrate": 1.2
                 },
                 "hero": {
                     "color": "8b3f8fff",
@@ -599,7 +638,8 @@
                 "cells": {
                     "name": "Winston",
                     "pickrate": 3.1,
-                    "winrate": 44.7
+                    "winrate": 44.7,
+                    "banrate": 4.7
                 },
                 "hero": {
                     "color": "8f92aeff",
@@ -614,7 +654,8 @@
                 "cells": {
                     "name": "Wrecking Ball",
                     "pickrate": 4.2,
-                    "winrate": 45
+                    "winrate": 45,
+                    "banrate": 2.8
                 },
                 "hero": {
                     "color": "e2790aff",
@@ -629,7 +670,8 @@
                 "cells": {
                     "name": "Wuyang",
                     "pickrate": 14.5,
-                    "winrate": 58.7
+                    "winrate": 58.7,
+                    "banrate": 3.5
                 },
                 "hero": {
                     "color": "4c7fefff",
@@ -644,7 +686,8 @@
                 "cells": {
                     "name": "Zarya",
                     "pickrate": 3.7,
-                    "winrate": 42
+                    "winrate": 42,
+                    "banrate": 1.7
                 },
                 "hero": {
                     "color": "f65ea6ff",
@@ -659,7 +702,8 @@
                 "cells": {
                     "name": "Zenyatta",
                     "pickrate": 6.7,
-                    "winrate": 47.1
+                    "winrate": 47.1,
+                    "banrate": 1.6
                 },
                 "hero": {
                     "color": "fcee5aff",

--- a/tests/heroes/parsers/test_hero_stats_summary.py
+++ b/tests/heroes/parsers/test_hero_stats_summary.py
@@ -21,6 +21,82 @@ from app.domain.parsers.hero_stats_summary import (
 )
 
 
+def test_parse_hero_stats_json_normalizes_banrate():
+    json_data = {
+        "rates": {
+            "selected": {"map": "all-maps", "rq": "1"},
+            "rates": [
+                {
+                    "id": "ana",
+                    "hero": {"role": "SUPPORT"},
+                    "cells": {"pickrate": 22.3, "winrate": 43.1, "banrate": -1},
+                }
+            ],
+        }
+    }
+
+    result = parse_hero_stats_json(
+        json_data,
+        map_filter="all-maps",
+        gamemode=PlayerGamemode.COMPETITIVE,
+        gamemode_filter="1",
+    )
+
+    assert result == [
+        {"hero": "ana", "pickrate": 22.3, "winrate": 43.1, "banrate": 0.0}
+    ]
+
+
+def test_parse_hero_stats_json_omits_banrate_outside_competitive():
+    json_data = {
+        "rates": {
+            "selected": {"map": "all-maps", "rq": "0"},
+            "rates": [
+                {
+                    "id": "ana",
+                    "hero": {"role": "SUPPORT"},
+                    "cells": {"pickrate": 22.3, "winrate": 43.1, "banrate": 0},
+                }
+            ],
+        }
+    }
+
+    result = parse_hero_stats_json(
+        json_data,
+        map_filter="all-maps",
+        gamemode=PlayerGamemode.QUICKPLAY,
+        gamemode_filter="0",
+    )
+
+    assert result == [
+        {"hero": "ana", "pickrate": 22.3, "winrate": 43.1, "banrate": None}
+    ]
+
+
+def test_parse_hero_stats_json_order_by_banrate_outside_competitive_raises():
+    json_data = {
+        "rates": {
+            "selected": {"map": "all-maps", "rq": "0"},
+            "rates": [
+                {
+                    "id": "ana",
+                    "hero": {"role": "SUPPORT"},
+                    "cells": {"pickrate": 22.3, "winrate": 43.1, "banrate": 0},
+                }
+            ],
+        }
+    }
+
+    with pytest.raises(ParserBlizzardError):
+        parse_hero_stats_json(
+            json_data,
+            map_filter="all-maps",
+            gamemode=PlayerGamemode.QUICKPLAY,
+            gamemode_filter="0",
+            order_by="banrate:desc",
+        )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("extra_kwargs", "raises_error"),

--- a/tests/heroes/test_hero_stats_route.py
+++ b/tests/heroes/test_hero_stats_route.py
@@ -54,10 +54,30 @@ def test_get_hero_stats_response_shape(client: TestClient):
 
     first = response.json()[0]
 
-    assert set(first.keys()) == {"hero", "pickrate", "winrate"}
+    assert set(first.keys()) == {"hero", "pickrate", "winrate", "banrate"}
     assert isinstance(first["hero"], str)
     assert isinstance(first["pickrate"], float)
     assert isinstance(first["winrate"], float)
+    assert isinstance(first["banrate"], float)
+
+
+def test_get_hero_stats_response_shape_quickplay_has_no_banrate(client: TestClient):
+    with patch(
+        "app.domain.services.hero_service.HeroService.get_hero_stats",
+        return_value=(
+            [{"hero": "ana", "pickrate": 5.0, "winrate": 50.0, "banrate": None}],
+            False,
+            0,
+        ),
+    ):
+        response = client.get(
+            "/heroes/stats",
+            params={**_BASE_PARAMS, "gamemode": PlayerGamemode.QUICKPLAY},
+        )
+
+    first = response.json()[0]
+
+    assert set(first.keys()) == {"hero", "pickrate", "winrate"}
 
 
 def test_get_hero_stats_invalid_platform(client: TestClient):
@@ -134,6 +154,8 @@ def test_get_hero_stats_filter_by_invalid_competitive_division(client: TestClien
         "pickrate:desc",
         "winrate:asc",
         "winrate:desc",
+        "banrate:asc",
+        "banrate:desc",
     ],
 )
 def test_get_hero_stats_order_by(client: TestClient, order_by: str):
@@ -168,6 +190,19 @@ def test_get_hero_stats_order_by_pickrate_desc_is_sorted(client: TestClient):
     assert response.status_code == status.HTTP_200_OK
     pickrates = [hero["pickrate"] for hero in data]
     assert pickrates == sorted(pickrates, reverse=True)
+
+
+def test_get_hero_stats_order_by_banrate_desc_is_sorted(client: TestClient):
+    response = client.get(
+        "/heroes/stats",
+        params={**_BASE_PARAMS, "order_by": "banrate:desc"},
+    )
+
+    data = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    banrates = [hero["banrate"] for hero in data]
+    assert banrates == sorted(banrates, reverse=True)
 
 
 def test_get_hero_stats_order_by_hero_asc_is_sorted(client: TestClient):


### PR DESCRIPTION
## Summary by Sourcery

Add game-mode-aware ban-rate statistics to the hero stats API.

New Features:
- Expose competitive hero ban rates in hero statistics and support ordering results by ban rate.

Enhancements:
- Omit ban rate data from non-competitive responses and reject ban-rate ordering for unsupported game modes.

Tests:
- Add parser and route coverage for ban-rate normalization, availability, validation, and sorting.